### PR TITLE
fixed scale in constructor of shape

### DIFF
--- a/src/og/shapes/BaseShape.js
+++ b/src/og/shapes/BaseShape.js
@@ -132,7 +132,7 @@ class BaseShape {
          * @protected
          * @type {og.Mat4}
          */
-        this._mxScale = new Mat4().setIdentity();
+        this._mxScale = new Mat4().setIdentity().scale(this.scale);
 
         /**
          * Translation matrix.


### PR DESCRIPTION
before: setting a scale inside the constructor had no effect.
now: setting a scale inside the constructor scales the shape.

src/og/shapes/BaseShape.js
- set _mxScale in constructor to this.scale instead of 1