### PR TITLE
Update readme doc & rollup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ yarn add @openglobus/og
 ### Code: using umd lib
 
 ```html
-<link rel="stylesheet" href="./libs/og-0.8.10.css">
-<script src="./libs/og-0.8.10-umd.js"></script>
+<link rel="stylesheet" href="./libs/og.css">
+<script src="./libs/og.umd.js"></script>
 <div id="globus"></div>
 <script>
 
@@ -51,11 +51,11 @@ yarn add @openglobus/og
 ### Code: using esm lib
 
 ``` html
-<link rel="stylesheet" href="./libs/og-0.8.10.css">
+<link rel="stylesheet" href="./libs/og.css">
 <div id="globus"></div>
 <script type="module">
 
-  import { layer, Globe, terrain } from './libs/og-0.8.10-esm.js'
+  import { layer, Globe, terrain } from './libs/og.esm.js'
   const { XYZ } = layer
   const { GlobusTerrain } = terrain
 
@@ -105,13 +105,13 @@ Run
 npm run build
 ```
 
-Then, it will generate 3 files at `dist/@openglobus/`:
+Then, it will generate 5 files at `dist/@openglobus/`:
 
-- og-<currentVersion\>-umd.js
-- og-<currentVersion\>-umd.js.map
-- og-<currentVersion\>-esm.js
-- og-<currentVersion\>-esm.js.map
-- og-<currentVersion\>.css
+- og.umd.js
+- og.umd.js.map
+- og.esm.js
+- og.esm.js.map
+- og.css
 
 All JavaScript files are compressed by `terser` plugin.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # OpenGlobus
 
+English | [简体中文](README_CN.md)
+
 [OpenGlobus](http://www.openglobus.org/) is a javascript library designed to display interactive 3d maps and planets
 with map tiles, imagery and vector data, markers and 3d objects. It uses the WebGL technology, open source and
 completely free.

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,8 +21,8 @@ yarn add @openglobus/og
 ### 代码：使用 umd 引用
 
 ``` html
-<link rel="stylesheet" href="./libs/og-0.8.10.css">
-<script src="./libs/og-0.8.10-umd.js"></script>
+<link rel="stylesheet" href="./libs/og.css">
+<script src="./libs/og.umd.js"></script>
 <div id="globus"></div>
 <script>
 
@@ -47,11 +47,11 @@ yarn add @openglobus/og
 ### 代码：使用 esm 引用
 
 ```html
-<link rel="stylesheet" href="./libs/og-0.8.10.css">
+<link rel="stylesheet" href="./libs/og.css">
 <div id="globus"></div>
 <script type="module">
 
-  import { layer, Globe, terrain } from './libs/og-0.8.10-esm.js'
+  import { layer, Globe, terrain } from './libs/og.esm.js'
   const { XYZ } = layer
   const { GlobusTerrain } = terrain
 
@@ -104,11 +104,11 @@ npm run build
 
 随后会在 `dist/@openglobus/` 目录下生成下列 5 个文件：
 
-- og-<当前版本\>-umd.js
-- og-<当前版本\>-umd.js.map
-- og-<当前版本\>-esm.js
-- og-<当前版本\>-esm.js.map
-- og-<当前版本>.css
+- og.umd.js
+- og.umd.js.map
+- og.esm.js
+- og.esm.js.map
+- og.css
 
 其中，js 文件均使用 `terser` 插件进行了代码压缩。
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,6 +2,8 @@
 
 # OpenGlobus
 
+[English](README.md) | 简体中文
+
 [OpenGlobus](http://www.openglobus.org/) 是一个用于展示带有地图瓦片、影像、矢量数据、标注、三维物体的交互式三维地图（地球）的 JavaScript 库。它基于 WebGL 技术，开源且免费。
 
 这个库的主要目标是令三维地图的功能迅速且美观地展示，并且对用户友好，易于在相关的项目中实施。

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,14 +5,14 @@ import postcss from "rollup-plugin-postcss";
 
 const LIB_SUFFIX = process.env.entry ? `.${process.env.entry}` : "";
 const LIB_NAME = pkg.name + LIB_SUFFIX;
-const OUTPUT_NAME = `dist/${LIB_NAME}-${pkg.version}`;
+const OUTPUT_NAME = `dist/${LIB_NAME}.`;
 
 export default [
     {
         input: `src/og/index${LIB_SUFFIX}.js`,
         output: [
             {
-                file: `${OUTPUT_NAME}-umd.js`,
+                file: `${OUTPUT_NAME}umd.js`,
                 format: "umd",
                 name: "og",
                 sourcemap: true
@@ -24,7 +24,7 @@ export default [
         input: `src/og/index${LIB_SUFFIX}.js`,
         output: [
             {
-                file: `${OUTPUT_NAME}-esm.js`,
+                file: `${OUTPUT_NAME}esm.js`,
                 format: "esm",
                 sourcemap: true
             }
@@ -35,7 +35,7 @@ export default [
         input: `css/og.css`,
         output: [
             {
-                file: `${OUTPUT_NAME}.css`,
+                file: `${OUTPUT_NAME}css`,
                 format: "umd",
                 name: pkg.name,
                 sourcemap: false


### PR DESCRIPTION
In this pr, I update rollup config to get rid of version number in the library name after 'og'.

After running `build` script, it will generate the dist files as follows:

- og.umd.js
- og.umd.js.map
- og.esm.js
- og.esm.js.map
- og.css

Also I update the README doc.