### PR TITLE
refactor to use the class syntax

### DIFF
--- a/src/og/Extent.js
+++ b/src/og/Extent.js
@@ -14,305 +14,306 @@ import { LonLat } from './LonLat.js';
  * @param {og.LonLat} [sw] - South West extent corner coordiantes.
  * @param {og.LonLat} [ne] - North East extent corner coordiantes.
  */
-const Extent = function (sw, ne) {
+export class Extent {
+
+    constructor(sw, ne) {
+        /**
+         * @public
+         */
+        this.southWest = sw || new LonLat();
+        /**
+         * @public
+         */
+        this.northEast = ne || new LonLat();
+    }
+
+    /**
+     * Whole mercator extent.
+     * @const
+     */
+    static get FULL_MERC() { return new Extent(LonLat.SW_MERC, LonLat.NE_MERC) };
+
+    /**
+     * Degrees extent from north mercator limit to north pole.
+     * @const
+     */
+    static get NORTH_POLE_DEG() { return new Extent(LonLat.NW_MERC_DEG, new LonLat(180.0, 90.0)); }
+
+    /**
+     * Degrees extent from south pole to south mercator limit.
+     * @const
+     */
+    static get SOUTH_POLE_DEG() { return new Extent(new LonLat(-180.0, -90.0), LonLat.SE_MERC_DEG) };
+
+    /**
+     * Creates extent instance from values in array.
+     * @static
+     * @param {Array.<number,number,number,number>} arr - South west and north east longitude and latidudes packed in array.
+     * @return {og.Extent} Extent object.
+     */
+    static createFromArray(arr) {
+        return new Extent(new LonLat(arr[0], arr[1]), new LonLat(arr[2], arr[3]));
+    };
+
+    /**
+     * Creates bound extent instance by coordinate array.
+     * @static
+     * @param {Array.<og.LonLat>} arr - Coordinate array.
+     * @return {og.Extent} Extent object.
+     */
+    static createByCoordinates(arr) {
+        let lonmin = math.MAX, lonmax = math.MIN,
+            latmin = math.MAX, latmax = math.MIN;
+        for (let i = 0; i < arr.length; i++) {
+            const vi = arr[i];
+            if (vi.lon < lonmin) lonmin = vi.lon;
+            if (vi.lon > lonmax) lonmax = vi.lon;
+            if (vi.lat < latmin) latmin = vi.lat;
+            if (vi.lat > latmax) latmax = vi.lat;
+        }
+        return new Extent(new LonLat(lonmin, latmin), new LonLat(lonmax, latmax));
+    };
+
+    /**
+     * Creates bound extent instance by coordinate array.
+     * @static
+     * @param {Array.<Array<number,number>>} arr - Coordinate array.
+     * @return {og.Extent} Extent object.
+     */
+    static createByCoordinatesArr(arr) {
+        let lonmin = math.MAX, lonmax = math.MIN,
+            latmin = math.MAX, latmax = math.MIN;
+        for (let i = 0; i < arr.length; i++) {
+            const vi = arr[i];
+            if (vi[0] < lonmin) lonmin = vi[0];
+            if (vi[0] > lonmax) lonmax = vi[0];
+            if (vi[1] < latmin) latmin = vi[1];
+            if (vi[1] > latmax) latmax = vi[1];
+        }
+        return new Extent(new LonLat(lonmin, latmin), new LonLat(lonmax, latmax));
+    };
+
+    /**
+     * Creates extent by meractor grid tile coordinates.
+     * @static
+     * @param {number} x -
+     * @param {number} y -
+     * @param {number} z -
+     * @param {number} width -
+     * @param {number} height -
+     * @returns {og.Extent} -
+     */
+    static fromTile(x, y, z, width, height) {
+        width = width || mercator.POLE_DOUBLE;
+        height = height || mercator.POLE_DOUBLE;
+        const H = Math.pow(2, z),
+            W = Math.pow(2, z),
+            lnSize = width / W,
+            ltSize = height / H;
+
+        const left = -width * 0.5 + x * lnSize,
+            top = height * 0.5 - y * ltSize,
+            bottom = top - ltSize,
+            right = left + lnSize;
+
+        return new Extent(new LonLat(left, bottom), new LonLat(right, top));
+    };
+
+    /**
+     * Sets current bounding extent object by coordinate array.
+     * @public
+     * @param {Array.<og.LonLat>} arr - Coordinate array.
+     * @return {og.Extent} Current extent.
+     */
+    setByCoordinates(arr) {
+        let lonmin = math.MAX, lonmax = math.MIN,
+            latmin = math.MAX, latmax = math.MIN;
+        for (let i = 0; i < arr.length; i++) {
+            const vi = arr[i];
+            if (vi.lon < lonmin) lonmin = vi.lon;
+            if (vi.lon > lonmax) lonmax = vi.lon;
+            if (vi.lat < latmin) latmin = vi.lat;
+            if (vi.lat > latmax) latmax = vi.lat;
+        }
+        this.southWest.lon = lonmin;
+        this.southWest.lat = latmin;
+        this.northEast.lon = lonmax;
+        this.northEast.lat = latmax;
+        return this;
+    };
+
+    /**
+     * Determines if point inside extent.
+     * @public
+     * @param {LonLat} lonlat - Coordinate point.
+     * @return {boolean} Returns true if point inside extent.
+     */
+    isInside(lonlat) {
+        const sw = this.southWest,
+            ne = this.northEast;
+        return lonlat.lon >= sw.lon && lonlat.lon <= ne.lon &&
+            lonlat.lat >= sw.lat && lonlat.lat <= ne.lat;
+    };
+
+    /**
+     * Returns true if two extent overlap each other.
+     * @public
+     * @param {Extent} e - Another extent.
+     * @return {boolean} -
+     */
+    overlaps(e) {
+        const sw = this.southWest,
+            ne = this.northEast;
+        return sw.lon <= e.northEast.lon && ne.lon >= e.southWest.lon &&
+            sw.lat <= e.northEast.lat && ne.lat >= e.southWest.lat;
+    };
+
+    /**
+     * Gets extent width.
+     * @public
+     * @return {number} Extent width.
+     */
+    getWidth() {
+        return this.northEast.lon - this.southWest.lon;
+    };
+
+    /**
+     * Gets extent height.
+     * @public
+     * @return {number} Extent height.
+     */
+    getHeight() {
+        return this.northEast.lat - this.southWest.lat;
+    };
+
+    /**
+     * Creates clone instance of the current extent.
+     * @public
+     * @return {og.Extent} Extent clone.
+     */
+    clone() {
+        return new Extent(this.southWest.clone(), this.northEast.clone());
+    };
+
+    /**
+     * Gets the center coordinate of the extent.
+     * @public
+     * @return {number} Center coordinate.
+     */
+    getCenter() {
+        const sw = this.southWest, ne = this.northEast;
+        return new LonLat(sw.lon + (ne.lon - sw.lon) * 0.5, sw.lat + (ne.lat - sw.lat) * 0.5);
+    };
+
     /**
      * @public
      */
-    this.southWest = sw || new LonLat();
+    getNorthWest() {
+        return new LonLat(this.southWest.lon, this.northEast.lat);
+    };
 
     /**
      * @public
      */
-    this.northEast = ne || new LonLat();
-};
+    getNorthEast() {
+        return new LonLat(this.northEast.lon, this.northEast.lat);
+    };
 
-/**
- * Whole mercator extent.
- * @const
- */
-Extent.FULL_MERC = new Extent(LonLat.SW_MERC, LonLat.NE_MERC);
+    getSouthWest() {
+        return new LonLat(this.southWest.lon, this.southWest.lat);
+    };
 
-/**
- * Degrees extent from north mercator limit to north pole.
- * @const
- */
-Extent.NORTH_POLE_DEG = new Extent(LonLat.NW_MERC_DEG, new LonLat(180.0, 90.0));
+    /**
+     * @public
+     */
+    getSouthEast() {
+        return new LonLat(this.northEast.lon, this.southWest.lat);
+    };
 
-/**
- * Degrees extent from south pole to south mercator limit.
- * @const
- */
-Extent.SOUTH_POLE_DEG = new Extent(new LonLat(-180.0, -90.0), LonLat.SE_MERC_DEG);
+    /**
+     * @public
+     */
+    getNorth() {
+        return this.northEast.lat;
+    };
 
-/**
- * Creates extent instance from values in array.
- * @static
- * @param {Array.<number,number,number,number>} arr - South west and north east longitude and latidudes packed in array.
- * @return {og.Extent} Extent object.
- */
-Extent.createFromArray = function (arr) {
-    return new Extent(new LonLat(arr[0], arr[1]), new LonLat(arr[2], arr[3]));
-};
+    getEast() {
+        return this.northEast.lon;
+    };
 
-/**
- * Creates bound extent instance by coordinate array.
- * @static
- * @param {Array.<og.LonLat>} arr - Coordinate array.
- * @return {og.Extent} Extent object.
- */
-Extent.createByCoordinates = function (arr) {
-    var lonmin = math.MAX, lonmax = math.MIN,
-        latmin = math.MAX, latmax = math.MIN;
-    for (var i = 0; i < arr.length; i++) {
-        var vi = arr[i];
-        if (vi.lon < lonmin) lonmin = vi.lon;
-        if (vi.lon > lonmax) lonmax = vi.lon;
-        if (vi.lat < latmin) latmin = vi.lat;
-        if (vi.lat > latmax) latmax = vi.lat;
-    }
-    return new Extent(new LonLat(lonmin, latmin), new LonLat(lonmax, latmax));
-};
+    /**
+     * @public
+     */
+    getWest() {
+        return this.southWest.lon;
+    };
 
-/**
- * Creates bound extent instance by coordinate array.
- * @static
- * @param {Array.<Array<number,number>>} arr - Coordinate array.
- * @return {og.Extent} Extent object.
- */
-Extent.createByCoordinatesArr = function (arr) {
-    var lonmin = math.MAX, lonmax = math.MIN,
-        latmin = math.MAX, latmax = math.MIN;
-    for (var i = 0; i < arr.length; i++) {
-        var vi = arr[i];
-        if (vi[0] < lonmin) lonmin = vi[0];
-        if (vi[0] > lonmax) lonmax = vi[0];
-        if (vi[1] < latmin) latmin = vi[1];
-        if (vi[1] > latmax) latmax = vi[1];
-    }
-    return new Extent(new LonLat(lonmin, latmin), new LonLat(lonmax, latmax));
-};
+    /**
+     * @public
+     */
+    getSouth() {
+        return this.southWest.lat;
+    };
 
-/**
- * Creates extent by meractor grid tile coordinates.
- * @static
- * @param {number} x -
- * @param {number} y -
- * @param {number} z -
- * @param {number} width -
- * @param {number} height -
- * @returns {og.Extent} -
- */
-Extent.fromTile = function (x, y, z, width, height) {
-    width = width || mercator.POLE_DOUBLE;
-    height = height || mercator.POLE_DOUBLE;
-    var H = Math.pow(2, z),
-        W = Math.pow(2, z),
-        lnSize = width / W,
-        ltSize = height / H;
+    /**
+     * Returns extents are equals.
+     * @param {og.Extent} extent - Extent.
+     * @returns {boolean} -
+     */
+    equals(extent) {
+        return this.southWest.lon === extent.southWest.lon && this.southWest.lat === extent.southWest.lat &&
+            this.northEast.lon === extent.northEast.lon && this.northEast.lat === extent.northEast.lat;
+    };
 
-    var left = -width * 0.5 + x * lnSize,
-        top = height * 0.5 - y * ltSize,
-        bottom = top - ltSize,
-        right = left + lnSize;
+    /**
+     * Converts extent coordinates to mercator projection coordinates.
+     * @public
+     * @return {og.Extent} New instance of the current extent.
+     */
+    forwardMercator() {
+        return new Extent(this.southWest.forwardMercator(), this.northEast.forwardMercator());
+    };
 
-    return new Extent(new LonLat(left, bottom), new LonLat(right, top));
-};
+    /**
+     * Converts extent coordinates from mercator projection to degrees.
+     * @public
+     * @return {og.Extent} New instance of the current extent.
+     */
+    inverseMercator() {
+        return new Extent(this.southWest.inverseMercator(), this.northEast.inverseMercator());
+    };
 
-/**
- * Sets current bounding extent object by coordinate array.
- * @public
- * @param {Array.<og.LonLat>} arr - Coordinate array.
- * @return {og.Extent} Current extent.
- */
-Extent.prototype.setByCoordinates = function (arr) {
-    var lonmin = math.MAX, lonmax = math.MIN,
-        latmin = math.MAX, latmax = math.MIN;
-    for (var i = 0; i < arr.length; i++) {
-        var vi = arr[i];
-        if (vi.lon < lonmin) lonmin = vi.lon;
-        if (vi.lon > lonmax) lonmax = vi.lon;
-        if (vi.lat < latmin) latmin = vi.lat;
-        if (vi.lat > latmax) latmax = vi.lat;
-    }
-    this.southWest.lon = lonmin;
-    this.southWest.lat = latmin;
-    this.northEast.lon = lonmax;
-    this.northEast.lat = latmax;
-    return this;
-};
+    /**
+     * Gets cartesian bounding bounds of the current ellipsoid.
+     * @public
+     * @param {og.Ellipsoid} ellipsoid - Ellipsoid.
+     * @return {Array.<number,number,number,number,number,number>} Cartesian 3d coordinate array.
+     */
+    getCartesianBounds(ellipsoid) {
+        let xmin = math.MAX, xmax = math.MIN, ymin = math.MAX,
+            ymax = math.MIN, zmin = math.MAX, zmax = math.MIN;
 
-/**
- * Determines if point inside extent.
- * @public
- * @param {LonLat} lonlat - Coordinate point.
- * @return {boolean} Returns true if point inside extent.
- */
-Extent.prototype.isInside = function (lonlat) {
-    var sw = this.southWest,
-        ne = this.northEast;
-    return lonlat.lon >= sw.lon && lonlat.lon <= ne.lon &&
-        lonlat.lat >= sw.lat && lonlat.lat <= ne.lat;
-};
+        const v = [new LonLat(this.southWest.lon, this.southWest.lat),
+        new LonLat(this.southWest.lon, this.northEast.lat),
+        new LonLat(this.northEast.lon, this.northEast.lat),
+        new LonLat(this.northEast.lon, this.southWest.lat)];
 
-/**
- * Returns true if two extent overlap each other.
- * @public
- * @param {Extent} e - Another extent.
- * @return {boolean} -
- */
-Extent.prototype.overlaps = function (e) {
-    var sw = this.southWest,
-        ne = this.northEast;
-    return sw.lon <= e.northEast.lon && ne.lon >= e.southWest.lon &&
-        sw.lat <= e.northEast.lat && ne.lat >= e.southWest.lat;
-};
+        for (let i = 0; i < v.length; i++) {
+            const coord = ellipsoid.lonLatToCartesian(v[i]);
+            const x = coord.x, y = coord.y, z = coord.z;
+            if (x < xmin) xmin = x;
+            if (x > xmax) xmax = x;
+            if (y < ymin) ymin = y;
+            if (y > ymax) ymax = y;
+            if (z < zmin) zmin = z;
+            if (z > zmax) zmax = z;
+        }
 
-/**
- * Gets extent width.
- * @public
- * @return {number} Extent width.
- */
-Extent.prototype.getWidth = function () {
-    return this.northEast.lon - this.southWest.lon;
-};
+        return [xmin, ymin, zmin, xmax, ymax, zmax];
+    };
 
-/**
- * Gets extent height.
- * @public
- * @return {number} Extent height.
- */
-Extent.prototype.getHeight = function () {
-    return this.northEast.lat - this.southWest.lat;
-};
+    toString() {
+        return "[" + this.southWest.lon + ", " + this.southWest.lat + ", " + this.northEast.lon + ", " + this.northEast.lat + "]";
+    };
 
-/**
- * Creates clone instance of the current extent.
- * @public
- * @return {og.Extent} Extent clone.
- */
-Extent.prototype.clone = function () {
-    return new Extent(this.southWest.clone(), this.northEast.clone());
-};
-
-/**
- * Gets the center coordinate of the extent.
- * @public
- * @return {number} Center coordinate.
- */
-Extent.prototype.getCenter = function () {
-    var sw = this.southWest, ne = this.northEast;
-    return new LonLat(sw.lon + (ne.lon - sw.lon) * 0.5, sw.lat + (ne.lat - sw.lat) * 0.5);
-};
-
-/**
- * @public
- */
-Extent.prototype.getNorthWest = function () {
-    return new LonLat(this.southWest.lon, this.northEast.lat);
-};
-
-/**
- * @public
- */
-Extent.prototype.getNorthEast = function () {
-    return new LonLat(this.northEast.lon, this.northEast.lat);
-};
-
-Extent.prototype.getSouthWest = function () {
-    return new LonLat(this.southWest.lon, this.southWest.lat);
-};
-
-/**
- * @public
- */
-Extent.prototype.getSouthEast = function () {
-    return new LonLat(this.northEast.lon, this.southWest.lat);
-};
-
-/**
- * @public
- */
-Extent.prototype.getNorth = function () {
-    return this.northEast.lat;
-};
-
-Extent.prototype.getEast = function () {
-    return this.northEast.lon;
-};
-
-/**
- * @public
- */
-Extent.prototype.getWest = function () {
-    return this.southWest.lon;
-};
-
-/**
- * @public
- */
-Extent.prototype.getSouth = function () {
-    return this.southWest.lat;
-};
-
-/**
- * Returns extents are equals.
- * @param {og.Extent} extent - Extent.
- * @returns {boolean} -
- */
-Extent.prototype.equals = function (extent) {
-    return this.southWest.lon === extent.southWest.lon && this.southWest.lat === extent.southWest.lat &&
-        this.northEast.lon === extent.northEast.lon && this.northEast.lat === extent.northEast.lat;
-};
-
-/**
- * Converts extent coordinates to mercator projection coordinates.
- * @public
- * @return {og.Extent} New instance of the current extent.
- */
-Extent.prototype.forwardMercator = function () {
-    return new Extent(this.southWest.forwardMercator(), this.northEast.forwardMercator());
-};
-
-/**
- * Converts extent coordinates from mercator projection to degrees.
- * @public
- * @return {og.Extent} New instance of the current extent.
- */
-Extent.prototype.inverseMercator = function () {
-    return new Extent(this.southWest.inverseMercator(), this.northEast.inverseMercator());
-};
-
-/**
- * Gets cartesian bounding bounds of the current ellipsoid.
- * @public
- * @param {og.Ellipsoid} ellipsoid - Ellipsoid.
- * @return {Array.<number,number,number,number,number,number>} Cartesian 3d coordinate array.
- */
-Extent.prototype.getCartesianBounds = function (ellipsoid) {
-    var xmin = math.MAX, xmax = math.MIN, ymin = math.MAX,
-        ymax = math.MIN, zmin = math.MAX, zmax = math.MIN;
-
-    var v = [new LonLat(this.southWest.lon, this.southWest.lat),
-    new LonLat(this.southWest.lon, this.northEast.lat),
-    new LonLat(this.northEast.lon, this.northEast.lat),
-    new LonLat(this.northEast.lon, this.southWest.lat)];
-
-    for (var i = 0; i < v.length; i++) {
-        var coord = ellipsoid.lonLatToCartesian(v[i]);
-        var x = coord.x, y = coord.y, z = coord.z;
-        if (x < xmin) xmin = x;
-        if (x > xmax) xmax = x;
-        if (y < ymin) ymin = y;
-        if (y > ymax) ymax = y;
-        if (z < zmin) zmin = z;
-        if (z > zmax) zmax = z;
-    }
-
-    return [xmin, ymin, zmin, xmax, ymax, zmax];
-};
-
-Extent.prototype.toString = function () {
-    return "[" + this.southWest.lon + ", " + this.southWest.lat + ", " + this.northEast.lon + ", " + this.northEast.lat + "]";
-};
-
-export { Extent };
+}

--- a/src/og/LonLat.js
+++ b/src/og/LonLat.js
@@ -19,166 +19,167 @@ const INV_PI_BY_180_HALF_PI = INV_PI_BY_180 * HALF_PI;
  * @param {number} [lat] - Latitude.
  * @param {number} [height] - Height over the surface.
  */
-const LonLat = function (lon, lat, height) {
+export class LonLat {
+
+    constructor(lon, lat, height) {
+
+        /**
+         * Longitude.
+         * @public
+         * @type {number}
+         */
+        this.lon = lon || 0;
+
+        /**
+         * Latitude.
+         * @public
+         * @type {number}
+         */
+        this.lat = lat || 0;
+
+        /**
+         * Height.
+         * @public
+         * @type {number}
+         */
+        this.height = height || 0;
+    };
+
+    isZero() {
+        return this.lon === 0.0 && this.lat === 0.0 && this.height === 0.0;
+    };
 
     /**
-     * Longitude.
-     * @public
-     * @type {number}
+     * Creates coordinates array.
+     * @static
+     * @param{Array.<Array<number,number,number>>} arr - Coordinates array data.
+     * @return{Array.<og.LonLat>} the same coordinates array but each element is LonLat instance.
      */
-    this.lon = lon || 0;
+    static join(arr) {
+        var res = [];
+        for (var i = 0; i < arr.length; i++) {
+            var ai = arr[i];
+            res[i] = new LonLat(ai[0], ai[1], ai[2]);
+        }
+        return res;
+    };
 
     /**
-     * Latitude.
-     * @public
-     * @type {number}
+     * Creates an object by coordinate array.
+     * @static
+     * @param {Array.<number,number,number>} arr - Coordiante array, where first is longitude, second is latitude and third is a height.
+     * @returns {og.LonLat} -
      */
-    this.lat = lat || 0;
+    static createFromArray(arr) {
+        return new LonLat(arr[0], arr[1], arr[2]);
+    };
 
     /**
-     * Height.
-     * @public
-     * @type {number}
+     * Converts degrees to mercator coordinates.
+     * @static
+     * @param {number} lon - Degrees longitude.
+     * @param {number} lat - Degrees latitude.
+     * @param {number} [height] - Height.
+     * @returns {og.LonLat} -
      */
-    this.height = height || 0;
-};
+    static forwardMercator(lon, lat, height) {
+        return new LonLat(lon * mercator.POLE_BY_180,
+            Math.log(Math.tan((90.0 + lat) * PI_BY_360)) * mercator.POLE_BY_PI,
+            height);
+    };
 
-LonLat.prototype.isZero = function () {
-    return this.lon === 0.0 && this.lat === 0.0 && this.height === 0.0;
-};
+    /**
+     * Converts mercator to degrees coordinates.
+     * @static
+     * @param {number} x - Mercator longitude.
+     * @param {number} y - Mercator latitude.
+     * @param {number} [height] - Height.
+     * @returns {og.LonLat} -
+     */
+    static inverseMercator(x, y, height) {
+        return new LonLat(x * mercator.INV_POLE_BY_180,
+            INV_PI_BY_360 * Math.atan(Math.exp(y * mercator.PI_BY_POLE)) - INV_PI_BY_180_HALF_PI,
+            height);
+    };
 
-/**
- * Creates coordinates array.
- * @static
- * @param{Array.<Array<number,number,number>>} arr - Coordinates array data.
- * @return{Array.<og.LonLat>} the same coordinates array but each element is LonLat instance.
- */
-LonLat.join = function (arr) {
-    var res = [];
-    for (var i = 0; i < arr.length; i++) {
-        var ai = arr[i];
-        res[i] = new LonLat(ai[0], ai[1], ai[2]);
-    }
-    return res;
-};
+    /**
+     * Sets coordinates.
+     * @public
+     * @param {number} [lon] - Longitude.
+     * @param {number} [lat] - Latitude.
+     * @param {number} [height] - Height.
+     * @returns {og.LonLat} -
+     */
+    set(lon, lat, height) {
+        this.lon = lon || 0;
+        this.lat = lat || 0;
+        this.height = height || 0;
+        return this;
+    };
 
-/**
- * Creates an object by coordinate array.
- * @static
- * @param {Array.<number,number,number>} arr - Coordiante array, where first is longitude, second is latitude and third is a height.
- * @returns {og.LonLat} -
- */
-LonLat.createFromArray = function (arr) {
-    return new LonLat(arr[0], arr[1], arr[2]);
-};
+    /**
+     * Copy coordinates.
+     * @public
+     * @param {og.LonLat} [lonLat] - Coordinates to copy.
+     * @returns {og.LonLat} -
+     */
+    copy(lonLat) {
+        this.lon = lonLat.lon;
+        this.lat = lonLat.lat;
+        this.height = lonLat.height;
+        return this;
+    };
 
-/**
- * Converts degrees to mercator coordinates.
- * @static
- * @param {number} lon - Degrees longitude.
- * @param {number} lat - Degrees latitude.
- * @param {number} [height] - Height.
- * @returns {og.LonLat} -
- */
-LonLat.forwardMercator = function (lon, lat, height) {
-    return new LonLat(lon * mercator.POLE_BY_180,
-        Math.log(Math.tan((90.0 + lat) * PI_BY_360)) * mercator.POLE_BY_PI,
-        height);
-};
+    /**
+     * Clone the coordiante.
+     * @public
+     * @returns {og.LonLat} -
+     */
+    clone() {
+        return new LonLat(this.lon, this.lat, this.height);
+    };
 
-/**
- * Converts mercator to degrees coordinates.
- * @static
- * @param {number} x - Mercator longitude.
- * @param {number} y - Mercator latitude.
- * @param {number} [height] - Height.
- * @returns {og.LonLat} -
- */
-LonLat.inverseMercator = function (x, y, height) {
-    return new LonLat(x * mercator.INV_POLE_BY_180,
-        INV_PI_BY_360 * Math.atan(Math.exp(y * mercator.PI_BY_POLE)) - INV_PI_BY_180_HALF_PI,
-        height);
-};
+    /**
+     * Converts to mercator coordinates.
+     * @public
+     * @returns {og.LonLat} -
+     */
+    forwardMercator() {
+        return LonLat.forwardMercator(this.lon, this.lat, this.height);
+    };
 
-/**
- * Sets coordinates.
- * @public
- * @param {number} [lon] - Longitude.
- * @param {number} [lat] - Latitude.
- * @param {number} [height] - Height.
- * @returns {og.LonLat} -
- */
-LonLat.prototype.set = function (lon, lat, height) {
-    this.lon = lon || 0;
-    this.lat = lat || 0;
-    this.height = height || 0;
-    return this;
-};
+    forwardMercatorEPS01() {
+        var lat = this.lat;
+        if (lat > 89.9) {
+            lat = 89.9;
+        } else if (lat < -89.9) {
+            lat = -89.9;
+        }
+        return new LonLat(
+            this.lon * mercator.POLE_BY_180,
+            Math.log(Math.tan((90.0 + lat) * PI_BY_360)) * mercator.POLE_BY_PI);
+    };
 
-/**
- * Copy coordinates.
- * @public
- * @param {og.LonLat} [lonLat] - Coordinates to copy.
- * @returns {og.LonLat} -
- */
-LonLat.prototype.copy = function (lonLat) {
-    this.lon = lonLat.lon;
-    this.lat = lonLat.lat;
-    this.height = lonLat.height;
-    return this;
-};
+    /**
+     * Converts from mercator coordinates.
+     * @public
+     * @returns {og.LonLat} -
+     */
+    inverseMercator() {
+        return LonLat.inverseMercator(this.lon, this.lat, this.height);
+    };
 
-/**
- * Clone the coordiante.
- * @public
- * @returns {og.LonLat} -
- */
-LonLat.prototype.clone = function () {
-    return new LonLat(this.lon, this.lat, this.height);
-};
-
-/**
- * Converts to mercator coordinates.
- * @public
- * @returns {og.LonLat} -
- */
-LonLat.prototype.forwardMercator = function () {
-    return LonLat.forwardMercator(this.lon, this.lat, this.height);
-};
-
-LonLat.prototype.forwardMercatorEPS01 = function () {
-    var lat = this.lat;
-    if (lat > 89.9) {
-        lat = 89.9;
-    } else if (lat < -89.9) {
-        lat = -89.9;
-    }
-    return new LonLat(
-        this.lon * mercator.POLE_BY_180,
-        Math.log(Math.tan((90.0 + lat) * PI_BY_360)) * mercator.POLE_BY_PI);
-};
-
-/**
- * Converts from mercator coordinates.
- * @public
- * @returns {og.LonLat} -
- */
-LonLat.prototype.inverseMercator = function () {
-    return LonLat.inverseMercator(this.lon, this.lat, this.height);
-};
-
-/**
- * Compares coordinates.
- * @public
- * @param {og.LonLat} b - Coordinate to compare with.
- * @returns {boolean} -
- */
-LonLat.prototype.equal = function (b) {
-    if (b.height) {
-        return this.lon === b.lon && this.lat === b.lat && this.height === b.height;
-    } else {
-        return this.lon === b.lon && this.lat === b.lat;
-    }
-};
-
-export { LonLat };
+    /**
+     * Compares coordinates.
+     * @public
+     * @param {og.LonLat} b - Coordinate to compare with.
+     * @returns {boolean} -
+     */
+    equal(b) {
+        if (b.height) {
+            return this.lon === b.lon && this.lat === b.lat && this.height === b.height;
+        } else {
+            return this.lon === b.lon && this.lat === b.lat;
+        }
+    };
+}

--- a/src/og/webgl/Handler.js
+++ b/src/og/webgl/Handler.js
@@ -33,969 +33,970 @@ const vendorPrefixes = ["", "WEBKIT_", "MOZ_"];
  * @param {Object} [param.scontext] - Native WebGL context attributes. See https://www.khronos.org/registry/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES
  * @param {Array.<string>} [params.extensions] - Additional WebGL extension list. Available by default: EXT_texture_filter_anisotropic.
  */
-const Handler = function (id, params) {
+export class Handler {
 
-    params = params || {};
+    constructor(id, params) {
 
-    /**
-     * Application default timer.
-     * @public
-     * @type {og.Clock}
-     */
-    this.defaultClock = new Clock();
+        params = params || {};
 
-    /**
-     * Custom timers.
-     * @protected
-     * @type{og.Clock[]}
-     */
-    this._clocks = [];
+        /**
+         * Application default timer.
+         * @public
+         * @type {og.Clock}
+         */
+        this.defaultClock = new Clock();
 
-    /**
-     * Draw frame time in milliseconds.
-     * @public
-     * @readonly
-     * @type {number}
-     */
-    this.deltaTime = 0;
+        /**
+         * Custom timers.
+         * @protected
+         * @type{og.Clock[]}
+         */
+        this._clocks = [];
 
-    /**
-     * WebGL rendering canvas element.
-     * @public
-     * @type {Object}
-     */
-    this.canvas = null;
+        /**
+         * Draw frame time in milliseconds.
+         * @public
+         * @readonly
+         * @type {number}
+         */
+        this.deltaTime = 0;
 
-    /**
-     * WebGL context.
-     * @public
-     * @type {Object}
-     */
-    this.gl = null;
+        /**
+         * WebGL rendering canvas element.
+         * @public
+         * @type {Object}
+         */
+        this.canvas = null;
 
-    /**
-     * Shader program controller list.
-     * @public
-     * @type {Object.<og.webgl.ProgramController>}
-     */
-    this.programs = {};
+        /**
+         * WebGL context.
+         * @public
+         * @type {Object}
+         */
+        this.gl = null;
 
-    /**
-     * Current active shader program controller.
-     * @public
-     * @type {og.webgl.ProgramController}
-     */
-    this.activeProgram = null;
+        /**
+         * Shader program controller list.
+         * @public
+         * @type {Object.<og.webgl.ProgramController>}
+         */
+        this.programs = {};
 
-    /**
-     * Handler parameters.
-     * @private
-     * @type {Object}
-     */
-    this._params = params || {};
-    this._params.anisotropy = this._params.anisotropy || 8;
-    var w = this._params.width;
-    if (w > MAX_SIZE) {
-        w = MAX_SIZE;
-    }
-    this._params.width = w || 256;
+        /**
+         * Current active shader program controller.
+         * @public
+         * @type {og.webgl.ProgramController}
+         */
+        this.activeProgram = null;
 
-    var h = this._params.height;
-    if (h > MAX_SIZE) {
-        h = MAX_SIZE;
-    }
-    this._params.height = h || 256;
-    this._params.context = this._params.context || {};
-    this._params.extensions = this._params.extensions || [];
-    this._oneByHeight = 1 / this._params.height;
-
-    /**
-     * Current WebGL extensions. Becomes here after context initialization.
-     * @public
-     * @type {Object}
-     */
-    this.extensions = {};
-
-    /**
-     * HTML Canvas object id.
-     * @private
-     * @type {Object}
-     */
-    this._id = id;
-
-    this._lastAnimationFrameTime = 0;
-
-    this._initialized = false;
-
-    /**
-     * Animation frame function assigned from outside(Ex. from Renderer).
-     * @private
-     * @type {frameCallback}
-     */
-    this._frameCallback = function () { };
-
-    this.transparentTexture = null;
-
-    this.framebufferStack = new Stack();
-
-    if (params.autoActivate || isEmpty(params.autoActivate)) {
-        this.initialize();
-    }
-};
-
-/**
- * The return value is null if the extension is not supported, or an extension object otherwise.
- * @param {Object} gl - WebGl context pointer.
- * @param {String} name - Extension name.
- * @returns {Object} -
- */
-Handler.getExtension = function (gl, name) {
-    var i, ext;
-    for (i in vendorPrefixes) {
-        ext = gl.getExtension(vendorPrefixes[i] + name);
-        if (ext) {
-            return ext;
+        /**
+         * Handler parameters.
+         * @private
+         * @type {Object}
+         */
+        this._params = params || {};
+        this._params.anisotropy = this._params.anisotropy || 8;
+        let w = this._params.width;
+        if (w > MAX_SIZE) {
+            w = MAX_SIZE;
         }
-    }
-    return null;
-};
+        this._params.width = w || 256;
 
-const CONTEXT_TYPE = ["webgl2", "webgl"];
+        var h = this._params.height;
+        if (h > MAX_SIZE) {
+            h = MAX_SIZE;
+        }
+        this._params.height = h || 256;
+        this._params.context = this._params.context || {};
+        this._params.extensions = this._params.extensions || [];
+        this._oneByHeight = 1 / this._params.height;
 
-/**
- * Returns a drawing context on the canvas, or null if the context identifier is not supported.
- * @param {Object} canvas - HTML canvas object.
- * @param {Object} [contextAttributes] - See canvas.getContext contextAttributes.
- * @returns {Object} -
- */
-Handler.getContext = function (canvas, contextAttributes) {
-    var ctx = null;
+        /**
+         * Current WebGL extensions. Becomes here after context initialization.
+         * @public
+         * @type {Object}
+         */
+        this.extensions = {};
 
-    try {
-        for (let i = 0; i < CONTEXT_TYPE.length; i++) {
-            ctx = canvas.getContext(CONTEXT_TYPE[i], contextAttributes);
-            if (ctx) {
-                ctx.type = CONTEXT_TYPE[i];
-                break;
+        /**
+         * HTML Canvas object id.
+         * @private
+         * @type {Object}
+         */
+        this._id = id;
+
+        this._lastAnimationFrameTime = 0;
+
+        this._initialized = false;
+
+        /**
+         * Animation frame function assigned from outside(Ex. from Renderer).
+         * @private
+         * @type {frameCallback}
+         */
+        this._frameCallback = function () { };
+
+        this.transparentTexture = null;
+
+        this.framebufferStack = new Stack();
+
+        if (params.autoActivate || isEmpty(params.autoActivate)) {
+            this.initialize();
+        }
+    };
+
+    /**
+     * The return value is null if the extension is not supported, or an extension object otherwise.
+     * @param {Object} gl - WebGl context pointer.
+     * @param {String} name - Extension name.
+     * @returns {Object} -
+     */
+    static getExtension(gl, name) {
+        var i, ext;
+        for (i in vendorPrefixes) {
+            ext = gl.getExtension(vendorPrefixes[i] + name);
+            if (ext) {
+                return ext;
             }
         }
-    } catch (ex) {
-        cons.logErr("exception during the GL context initialization");
-    }
+        return null;
+    };
 
-    if (!ctx) {
-        cons.logErr("could not initialise WebGL");
-    }
 
-    return ctx;
-};
+    /**
+     * Returns a drawing context on the canvas, or null if the context identifier is not supported.
+     * @param {Object} canvas - HTML canvas object.
+     * @param {Object} [contextAttributes] - See canvas.getContext contextAttributes.
+     * @returns {Object} -
+     */
+    static getContext(canvas, contextAttributes) {
+        const CONTEXT_TYPE = ["webgl2", "webgl"];
+        var ctx = null;
 
-/**
- * Sets animation frame function.
- * @public
- * @param {callback} callback - Frame callback.
- */
-Handler.prototype.setFrameCallback = function (callback) {
-    callback && (this._frameCallback = callback);
-};
+        try {
+            for (let i = 0; i < CONTEXT_TYPE.length; i++) {
+                ctx = canvas.getContext(CONTEXT_TYPE[i], contextAttributes);
+                if (ctx) {
+                    ctx.type = CONTEXT_TYPE[i];
+                    break;
+                }
+            }
+        } catch (ex) {
+            cons.logErr("exception during the GL context initialization");
+        }
 
-/**
- * Creates NEAREST filter texture.
- * @public
- * @param {Object} image - Image or Canvas object.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createTexture_n = function (image) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
+        if (!ctx) {
+            cons.logErr("could not initialise WebGL");
+        }
 
-/**
- * Creates empty texture.
- * @public
- * @param {Number} [width=1] - Specifies the width of the texture image..
- * @param {Number} [height=1] - Specifies the width of the texture image..
- * @param {String} [filter="NEAREST"] - Specifies GL_TEXTURE_MIN(MAX)_FILTER texture value.
- * @param {String} [internalFormat="RGBA"] - Specifies the color components in the texture.
- * @param {String} [format="RGBA"] - Specifies the format of the texel data.
- * @param {String} [type="UNSIGNED_BYTE"] - Specifies the data type of the texel data.
- * @param {Number} [levels=0] - Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap reduction image.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createEmptyTexture2DExt = function (
-    width = 1,
-    height = 1,
-    filter = "NEAREST",
-    internalFormat = "RGBA",
-    format = "RGBA",
-    type = "UNSIGNED_BYTE",
-    level = 0
-) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        return ctx;
+    };
 
-    gl.texImage2D(gl.TEXTURE_2D, level, gl[internalFormat.toUpperCase()], width, height, 0,
-        gl[format.toUpperCase()], gl[type.toUpperCase()], null);
+    /**
+     * Sets animation frame function.
+     * @public
+     * @param {callback} callback - Frame callback.
+     */
+    setFrameCallback = function (callback) {
+        callback && (this._frameCallback = callback);
+    };
 
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl[filter.toUpperCase()]);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl[filter.toUpperCase()]);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
-
-///**
-// * Creates Empty half float texture.
-// * @public
-// * @param {number} width - Empty texture width.
-// * @param {number} height - Empty texture height.
-// * @returns {Object} - WebGL half float texture object.
-// */
-//Handler.prototype.createEmptyTexture_hf = function (width, height) {
-//    var gl = this.gl;
-//    var texture = gl.createTexture();
-//    gl.bindTexture(gl.TEXTURE_2D, texture);
-//    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-//    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.HALF_FLOAT_OES, null);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-//    gl.bindTexture(gl.TEXTURE_2D, null);
-//    return texture;
-//}
-
-///**
-// * Creates Empty float texture.
-// * @public
-// * @param {number} width - Empty texture width.
-// * @param {number} height - Empty texture height.
-// * @returns {Object} - WebGL float texture object.
-// */
-//Handler.prototype.createEmptyTexture_f = function (width, height) {
-//    var gl = this.gl;
-//    var texture = gl.createTexture();
-//    gl.bindTexture(gl.TEXTURE_2D, texture);
-//    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-//    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.FLOAT, null);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-//    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-//    gl.bindTexture(gl.TEXTURE_2D, null);
-//    return texture;
-//}
-
-/**
- * Creates Empty NEAREST filtered texture.
- * @public
- * @param {number} width - Empty texture width.
- * @param {number} height - Empty texture height.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createEmptyTexture_n = function (width, height) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
-
-/**
- * Creates empty LINEAR filtered texture.
- * @public
- * @param {number} width - Empty texture width.
- * @param {number} height - Empty texture height.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createEmptyTexture_l = function (width, height) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
-
-/**
- * Creates LINEAR filter texture.
- * @public
- * @param {Object} image - Image or Canvas object.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createTexture_l = function (image) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
-
-/**
- * Creates MIPMAP filter texture.
- * @public
- * @param {Object} image - Image or Canvas object.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createTexture_mm = function (image) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-    gl.generateMipmap(gl.TEXTURE_2D);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
-
-/**
- * Creates ANISOTROPY filter texture.
- * @public
- * @param {Object} image - Image or Canvas object.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createTexture_a = function (image) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, texture);
-    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-    gl.generateMipmap(gl.TEXTURE_2D);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-    gl.texParameterf(gl.TEXTURE_2D, this.extensions.EXT_texture_filter_anisotropic.TEXTURE_MAX_ANISOTROPY_EXT, this._params.anisotropy);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    return texture;
-};
-
-/**
- * Creates DEFAULT filter texture, ANISOTROPY is default.
- * @public
- * @param {Object} image - Image or Canvas object.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.createTexture = function (image) {
-    return this.createTexture_a(image);
-};
-
-/**
- * Creates cube texture.
- * @public
- * @param {Object.<string>} params - Face image urls:
- * @param {string} params.px - Positive X or right image url.
- * @param {string} params.nx - Negative X or left image url.
- * @param {string} params.py - Positive Y or up image url.
- * @param {string} params.ny - Negative Y or bottom image url.
- * @param {string} params.pz - Positive Z or face image url.
- * @param {string} params.nz - Negative Z or back image url.
- * @returns {Object} - WebGL texture object.
- */
-Handler.prototype.loadCubeMapTexture = function (params) {
-    var gl = this.gl;
-    var texture = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
-    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-
-    var faces = [[params.px, gl.TEXTURE_CUBE_MAP_POSITIVE_X],
-    [params.nx, gl.TEXTURE_CUBE_MAP_NEGATIVE_X],
-    [params.py, gl.TEXTURE_CUBE_MAP_POSITIVE_Y],
-    [params.ny, gl.TEXTURE_CUBE_MAP_NEGATIVE_Y],
-    [params.pz, gl.TEXTURE_CUBE_MAP_POSITIVE_Z],
-    [params.nz, gl.TEXTURE_CUBE_MAP_NEGATIVE_Z]];
-
-    var imageCanvas = new ImageCanvas();
-    imageCanvas.fillEmpty();
-    var emptyImage = imageCanvas.getImage();
-
-    for (let i = 0; i < faces.length; i++) {
-        let face = faces[i][1];
-        gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
+    /**
+     * Creates NEAREST filter texture.
+     * @public
+     * @param {Object} image - Image or Canvas object.
+     * @returns {Object} - WebGL texture object.
+     */
+    createTexture_n = function (image) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-        gl.texImage2D(face, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, emptyImage);
-    }
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
 
-    for (let i = 0; i < faces.length; i++) {
-        let face = faces[i][1];
-        let image = new Image();
-        image.crossOrigin = '';
-        image.onload = (function (texture, face, image) {
-            return function () {
-                gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
-                gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-                gl.texImage2D(face, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-            };
-        }(texture, face, image));
-        image.src = faces[i][0];
-    }
-    return texture;
-};
+    /**
+     * Creates empty texture.
+     * @public
+     * @param {Number} [width=1] - Specifies the width of the texture image..
+     * @param {Number} [height=1] - Specifies the width of the texture image..
+     * @param {String} [filter="NEAREST"] - Specifies GL_TEXTURE_MIN(MAX)_FILTER texture value.
+     * @param {String} [internalFormat="RGBA"] - Specifies the color components in the texture.
+     * @param {String} [format="RGBA"] - Specifies the format of the texel data.
+     * @param {String} [type="UNSIGNED_BYTE"] - Specifies the data type of the texel data.
+     * @param {Number} [levels=0] - Specifies the level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap reduction image.
+     * @returns {Object} - WebGL texture object.
+     */
+    createEmptyTexture2DExt = function (
+        width = 1,
+        height = 1,
+        filter = "NEAREST",
+        internalFormat = "RGBA",
+        format = "RGBA",
+        type = "UNSIGNED_BYTE",
+        level = 0
+    ) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 
-/**
- * Adds shader program to the handler.
- * @public
- * @param {og.webgl.Program} program - Shader program.
- * @param {boolean} [notActivate] - If it's true program will not compile.
- * @return {og.webgl.Program} -
- */
-Handler.prototype.addProgram = function (program, notActivate) {
-    if (!this.programs[program.name]) {
-        var sc = new ProgramController(this, program);
-        this.programs[program.name] = sc;
-        this._initProgramController(sc);
-        if (notActivate) {
-            sc._activated = false;
+        gl.texImage2D(gl.TEXTURE_2D, level, gl[internalFormat.toUpperCase()], width, height, 0,
+            gl[format.toUpperCase()], gl[type.toUpperCase()], null);
+
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl[filter.toUpperCase()]);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl[filter.toUpperCase()]);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
+
+    ///**
+    // * Creates Empty half float texture.
+    // * @public
+    // * @param {number} width - Empty texture width.
+    // * @param {number} height - Empty texture height.
+    // * @returns {Object} - WebGL half float texture object.
+    // */
+    //createEmptyTexture_hf = function (width, height) {
+    //    var gl = this.gl;
+    //    var texture = gl.createTexture();
+    //    gl.bindTexture(gl.TEXTURE_2D, texture);
+    //    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+    //    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.HALF_FLOAT_OES, null);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    //    gl.bindTexture(gl.TEXTURE_2D, null);
+    //    return texture;
+    //}
+
+    ///**
+    // * Creates Empty float texture.
+    // * @public
+    // * @param {number} width - Empty texture width.
+    // * @param {number} height - Empty texture height.
+    // * @returns {Object} - WebGL float texture object.
+    // */
+    //createEmptyTexture_f = function (width, height) {
+    //    var gl = this.gl;
+    //    var texture = gl.createTexture();
+    //    gl.bindTexture(gl.TEXTURE_2D, texture);
+    //    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+    //    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.FLOAT, null);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    //    //gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    //    gl.bindTexture(gl.TEXTURE_2D, null);
+    //    return texture;
+    //}
+
+    /**
+     * Creates Empty NEAREST filtered texture.
+     * @public
+     * @param {number} width - Empty texture width.
+     * @param {number} height - Empty texture height.
+     * @returns {Object} - WebGL texture object.
+     */
+    createEmptyTexture_n = function (width, height) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
+
+    /**
+     * Creates empty LINEAR filtered texture.
+     * @public
+     * @param {number} width - Empty texture width.
+     * @param {number} height - Empty texture height.
+     * @returns {Object} - WebGL texture object.
+     */
+    createEmptyTexture_l = function (width, height) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
+
+    /**
+     * Creates LINEAR filter texture.
+     * @public
+     * @param {Object} image - Image or Canvas object.
+     * @returns {Object} - WebGL texture object.
+     */
+    createTexture_l = function (image) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
+
+    /**
+     * Creates MIPMAP filter texture.
+     * @public
+     * @param {Object} image - Image or Canvas object.
+     * @returns {Object} - WebGL texture object.
+     */
+    createTexture_mm = function (image) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+        gl.generateMipmap(gl.TEXTURE_2D);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
+
+    /**
+     * Creates ANISOTROPY filter texture.
+     * @public
+     * @param {Object} image - Image or Canvas object.
+     * @returns {Object} - WebGL texture object.
+     */
+    createTexture_a = function (image) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+        gl.generateMipmap(gl.TEXTURE_2D);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+        gl.texParameterf(gl.TEXTURE_2D, this.extensions.EXT_texture_filter_anisotropic.TEXTURE_MAX_ANISOTROPY_EXT, this._params.anisotropy);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return texture;
+    };
+
+    /**
+     * Creates DEFAULT filter texture, ANISOTROPY is default.
+     * @public
+     * @param {Object} image - Image or Canvas object.
+     * @returns {Object} - WebGL texture object.
+     */
+    createTexture = function (image) {
+        return this.createTexture_a(image);
+    };
+
+    /**
+     * Creates cube texture.
+     * @public
+     * @param {Object.<string>} params - Face image urls:
+     * @param {string} params.px - Positive X or right image url.
+     * @param {string} params.nx - Negative X or left image url.
+     * @param {string} params.py - Positive Y or up image url.
+     * @param {string} params.ny - Negative Y or bottom image url.
+     * @param {string} params.pz - Positive Z or face image url.
+     * @param {string} params.nz - Negative Z or back image url.
+     * @returns {Object} - WebGL texture object.
+     */
+    loadCubeMapTexture = function (params) {
+        var gl = this.gl;
+        var texture = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
+        gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+        var faces = [[params.px, gl.TEXTURE_CUBE_MAP_POSITIVE_X],
+        [params.nx, gl.TEXTURE_CUBE_MAP_NEGATIVE_X],
+        [params.py, gl.TEXTURE_CUBE_MAP_POSITIVE_Y],
+        [params.ny, gl.TEXTURE_CUBE_MAP_NEGATIVE_Y],
+        [params.pz, gl.TEXTURE_CUBE_MAP_POSITIVE_Z],
+        [params.nz, gl.TEXTURE_CUBE_MAP_NEGATIVE_Z]];
+
+        var imageCanvas = new ImageCanvas();
+        imageCanvas.fillEmpty();
+        var emptyImage = imageCanvas.getImage();
+
+        for (let i = 0; i < faces.length; i++) {
+            let face = faces[i][1];
+            gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+            gl.texImage2D(face, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, emptyImage);
         }
-    } else {
-        console.log("og.webgl.Handler:284 - shader program: '" + program.name + "' is allready exists.");
-    }
-    return program;
-};
 
-/**
- * Removes shader program from handler.
- * @public
- * @param {String} name - Shader program name.
- */
-Handler.prototype.removeProgram = function (name) {
-    this.programs[name] && this.programs[name].remove();
-};
+        for (let i = 0; i < faces.length; i++) {
+            let face = faces[i][1];
+            let image = new Image();
+            image.crossOrigin = '';
+            image.onload = (function (texture, face, image) {
+                return function () {
+                    gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
+                    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+                    gl.texImage2D(face, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+                };
+            }(texture, face, image));
+            image.src = faces[i][0];
+        }
+        return texture;
+    };
 
-/**
- * Adds shader programs to the handler.
- * @public
- * @param {Array.<og.webgl.Program>} programsArr - Shader program array.
- */
-Handler.prototype.addPrograms = function (programsArr) {
-    for (var i = 0; i < programsArr.length; i++) {
-        this.addProgram(programsArr[i]);
-    }
-};
-
-/**
- * Used in addProgram
- * @private
- * @param {og.webgl.ProgramController} sc - Program controller
- */
-Handler.prototype._initProgramController = function (sc) {
-    if (this._initialized) {
-        sc.initialize();
-        if (!this.activeProgram) {
-            this.activeProgram = sc;
-            sc.activate();
+    /**
+     * Adds shader program to the handler.
+     * @public
+     * @param {og.webgl.Program} program - Shader program.
+     * @param {boolean} [notActivate] - If it's true program will not compile.
+     * @return {og.webgl.Program} -
+     */
+    addProgram = function (program, notActivate) {
+        if (!this.programs[program.name]) {
+            var sc = new ProgramController(this, program);
+            this.programs[program.name] = sc;
+            this._initProgramController(sc);
+            if (notActivate) {
+                sc._activated = false;
+            }
         } else {
-            sc.deactivate();
-            this.activeProgram._program.enableAttribArrays();
-            this.activeProgram._program.use();
+            console.log("og.webgl.Handler:284 - shader program: '" + program.name + "' is allready exists.");
         }
-    }
-};
+        return program;
+    };
 
-/**
- * Used in init function.
- * @private
- */
-Handler.prototype._initPrograms = function () {
-    for (var p in this.programs) {
-        this._initProgramController(this.programs[p]);
-    }
-};
+    /**
+     * Removes shader program from handler.
+     * @public
+     * @param {String} name - Shader program name.
+     */
+    removeProgram = function (name) {
+        this.programs[name] && this.programs[name].remove();
+    };
 
-/**
- * Initialize additional WebGL extensions.
- * @public
- * @param {string} extensionStr - Extension name.
- * @param {boolean} showLog - Show logging.
- * @return {Object} -
- */
-Handler.prototype.initializeExtension = function (extensionStr, showLog) {
-    if (!(this.extensions && this.extensions[extensionStr])) {
-        var ext = Handler.getExtension(this.gl, extensionStr);
-        if (ext) {
-            this.extensions[extensionStr] = ext;
-        } else if (showLog) {
-            console.log("og.webgl.Handler: extension '" + extensionStr + "' doesn't initialize.");
+    /**
+     * Adds shader programs to the handler.
+     * @public
+     * @param {Array.<og.webgl.Program>} programsArr - Shader program array.
+     */
+    addPrograms = function (programsArr) {
+        for (var i = 0; i < programsArr.length; i++) {
+            this.addProgram(programsArr[i]);
         }
-    }
-    return this.extensions && this.extensions[extensionStr];
-};
+    };
 
-/**
- * Main function that initialize handler.
- * @public
- */
-Handler.prototype.initialize = function () {
+    /**
+     * Used in addProgram
+     * @private
+     * @param {og.webgl.ProgramController} sc - Program controller
+     */
+    _initProgramController = function (sc) {
+        if (this._initialized) {
+            sc.initialize();
+            if (!this.activeProgram) {
+                this.activeProgram = sc;
+                sc.activate();
+            } else {
+                sc.deactivate();
+                this.activeProgram._program.enableAttribArrays();
+                this.activeProgram._program.use();
+            }
+        }
+    };
 
-    if (this._id) {
-        this.canvas = document.getElementById(this._id);
-    } else {
-        this.canvas = document.createElement("canvas");
-        this.canvas.width = this._params.width;
-        this.canvas.height = this._params.height;
-    }
+    /**
+     * Used in init function.
+     * @private
+     */
+    _initPrograms = function () {
+        for (var p in this.programs) {
+            this._initProgramController(this.programs[p]);
+        }
+    };
 
-    this.gl = Handler.getContext(this.canvas, this._params.context);
-    this._initialized = true;
+    /**
+     * Initialize additional WebGL extensions.
+     * @public
+     * @param {string} extensionStr - Extension name.
+     * @param {boolean} showLog - Show logging.
+     * @return {Object} -
+     */
+    initializeExtension = function (extensionStr, showLog) {
+        if (!(this.extensions && this.extensions[extensionStr])) {
+            var ext = Handler.getExtension(this.gl, extensionStr);
+            if (ext) {
+                this.extensions[extensionStr] = ext;
+            } else if (showLog) {
+                console.log("og.webgl.Handler: extension '" + extensionStr + "' doesn't initialize.");
+            }
+        }
+        return this.extensions && this.extensions[extensionStr];
+    };
 
-    /** Sets deafult extensions */
-    this._params.extensions.push("EXT_texture_filter_anisotropic");
+    /**
+     * Main function that initialize handler.
+     * @public
+     */
+    initialize = function () {
 
-    if (this.gl.type === "webgl") {
-        this._params.extensions.push("OES_standard_derivatives");
-        this._params.extensions.push("OES_element_index_uint");
-        this._params.extensions.push("WEBGL_depth_texture");
-        //this._params.extensions.push("EXT_frag_depth");
-    } else {
-        this._params.extensions.push("EXT_color_buffer_float");
-        this._params.extensions.push("OES_texture_float_linear");
-    }
+        if (this._id) {
+            this.canvas = document.getElementById(this._id);
+        } else {
+            this.canvas = document.createElement("canvas");
+            this.canvas.width = this._params.width;
+            this.canvas.height = this._params.height;
+        }
 
-    var i = this._params.extensions.length;
-    while (i--) {
-        this.initializeExtension(this._params.extensions[i], true);
-    }
+        this.gl = Handler.getContext(this.canvas, this._params.context);
+        this._initialized = true;
 
-    if (!this.extensions.EXT_texture_filter_anisotropic) {
-        this.createTexture = this.createTexture_mm;
-    }
+        /** Sets deafult extensions */
+        this._params.extensions.push("EXT_texture_filter_anisotropic");
 
-    /** Initilalize shaders and rendering parameters*/
-    this._initPrograms();
-    this._setDefaults();
-};
+        if (this.gl.type === "webgl") {
+            this._params.extensions.push("OES_standard_derivatives");
+            this._params.extensions.push("OES_element_index_uint");
+            this._params.extensions.push("WEBGL_depth_texture");
+            //this._params.extensions.push("EXT_frag_depth");
+        } else {
+            this._params.extensions.push("EXT_color_buffer_float");
+            this._params.extensions.push("OES_texture_float_linear");
+        }
 
-/**
- * Sets default gl render parameters. Used in init function.
- * @private
- */
-Handler.prototype._setDefaults = function () {
-    this.activateDepthTest();
-    this.setSize(this.canvas.clientWidth || this._params.width, this.canvas.clientHeight || this._params.height);
-    this.gl.frontFace(this.gl.CCW);
-    this.gl.cullFace(this.gl.BACK);
-    this.activateFaceCulling();
-    this.deactivateBlending();
-    var that = this;
-    this.createDefaultTexture({ color: "rgba(0,0,0,0.0)" }, function (t) {
-        that.transparentTexture = t;
-    });
-};
+        var i = this._params.extensions.length;
+        while (i--) {
+            this.initializeExtension(this._params.extensions[i], true);
+        }
 
-/**
- * Activate depth test.
- * @public
- */
-Handler.prototype.activateDepthTest = function () {
-    this.gl.enable(this.gl.DEPTH_TEST);
-};
+        if (!this.extensions.EXT_texture_filter_anisotropic) {
+            this.createTexture = this.createTexture_mm;
+        }
 
-/**
- * Deactivate depth test.
- * @public
- */
-Handler.prototype.deactivateDepthTest = function () {
-    this.gl.disable(this.gl.DEPTH_TEST);
-};
+        /** Initilalize shaders and rendering parameters*/
+        this._initPrograms();
+        this._setDefaults();
+    };
 
-/**
- * Activate face culling.
- * @public
- */
-Handler.prototype.activateFaceCulling = function () {
-    this.gl.enable(this.gl.CULL_FACE);
-};
-
-/**
- * Deactivate face cullting.
- * @public
- */
-Handler.prototype.deactivateFaceCulling = function () {
-    this.gl.disable(this.gl.CULL_FACE);
-};
-
-/**
- * Activate blending.
- * @public
- */
-Handler.prototype.activateBlending = function () {
-    this.gl.enable(this.gl.BLEND);
-};
-
-/**
- * Deactivate blending.
- * @public
- */
-Handler.prototype.deactivateBlending = function () {
-    this.gl.disable(this.gl.BLEND);
-};
-
-/**
- * Creates STREAM_DRAW ARRAY buffer.
- * @public
- * @param {Array.<number>} array - Input array.
- * @param {number} itemSize - Array item size.
- * @param {number} numItems - Items quantity.
- * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
- * @return {Object} -
- */
-Handler.prototype.createStreamArrayBuffer = function (itemSize, numItems, usage, bites = 4) {
-    var buffer = this.gl.createBuffer();
-    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
-    this.gl.bufferData(this.gl.ARRAY_BUFFER, numItems * itemSize * bites, usage || this.gl.STREAM_DRAW);
-    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
-    buffer.itemSize = itemSize;
-    buffer.numItems = numItems;
-    return buffer;
-};
-
-/**
- * Load stream ARRAY buffer.
- * @public
- * @param {Array.<number>} array - Input array.
- * @param {number} itemSize - Array item size.
- * @param {number} numItems - Items quantity.
- * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
- * @return {Object} -
- */
-Handler.prototype.setStreamArrayBuffer = function (buffer, array, offset = 0) {
-    let gl = this.gl;
-    gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
-    gl.bufferSubData(this.gl.ARRAY_BUFFER, offset, array);
-    gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
-    return buffer;
-};
-
-/**
- * Creates ARRAY buffer.
- * @public
- * @param {Array.<number>} array - Input array.
- * @param {number} itemSize - Array item size.
- * @param {number} numItems - Items quantity.
- * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
- * @return {Object} -
- */
-Handler.prototype.createArrayBuffer = function (array, itemSize, numItems, usage) {
-    var buffer = this.gl.createBuffer();
-    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
-    this.gl.bufferData(this.gl.ARRAY_BUFFER, array, usage || this.gl.STATIC_DRAW);
-    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
-    buffer.itemSize = itemSize;
-    buffer.numItems = numItems;
-    return buffer;
-};
-
-/**
- * Creates ELEMENT ARRAY buffer.
- * @public
- * @param {Array.<number>} array - Input array.
- * @param {number} itemSize - Array item size.
- * @param {number} numItems - Items quantity.
- * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
- * @return {Object} -
- */
-Handler.prototype.createElementArrayBuffer = function (array, itemSize, numItems, usage) {
-    var buffer = this.gl.createBuffer();
-    this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, buffer);
-    this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, array, usage || this.gl.STATIC_DRAW);
-    this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, null);
-    buffer.itemSize = itemSize;
-    buffer.numItems = numItems || array.length;
-    return buffer;
-};
-
-/**
- * Sets handler canvas size.
- * @public
- * @param {number} w - Canvas width.
- * @param {number} h - Canvas height.
- */
-Handler.prototype.setSize = function (w, h) {
-
-    if (w > MAX_SIZE) {
-        w = MAX_SIZE;
-    }
-
-    if (h > MAX_SIZE) {
-        h = MAX_SIZE;
-    }
-
-    this._params.width = w;
-    this._params.height = h;
-    this.canvas.width = w;
-    this.canvas.height = h;
-    this._oneByHeight = 1 / h;
-
-    this.gl && this.gl.viewport(0, 0, w, h);
-    this.onCanvasResize && this.onCanvasResize(this.canvas);
-};
-
-/**
- * Returns context screen width.
- * @public
- * @returns {number} -
- */
-Handler.prototype.getWidth = function () {
-    return this.canvas.width;
-};
-
-/**
- * Returns context screen height.
- * @public
- * @returns {number} -
- */
-Handler.prototype.getHeight = function () {
-    return this.canvas.height;
-};
-
-/**
- * Returns canvas aspect ratio.
- * @public
- * @returns {number} -
- */
-Handler.prototype.getClientAspect = function () {
-    return this.canvas.clientWidth / this.canvas.clientHeight;
-};
-
-/**
- * Returns screen center coordinates.
- * @public
- * @returns {number} -
- */
-Handler.prototype.getCenter = function () {
-    var c = this.canvas;
-    return new Vec2(Math.round(c.width * 0.5), Math.round(c.height * 0.5));
-};
-
-/**
- * Draw single frame.
- * @public
- * @param {number} now - Frame current time milliseconds.
- */
-Handler.prototype.drawFrame = function () {
-
-    /** Calculating frame time */
-    var now = window.performance.now();
-    this.deltaTime = now - this._lastAnimationFrameTime;
-    this._lastAnimationFrameTime = now;
-
-    this.defaultClock._tick(this.deltaTime);
-
-    for (var i = 0; i < this._clocks.length; i++) {
-        this._clocks[i]._tick(this.deltaTime);
-    }
-
-    /** Canvas resize checking */
-    var canvas = this.canvas;
-    if (canvas.clientWidth !== canvas.width ||
-        canvas.clientHeight !== canvas.height) {
-        this.setSize(canvas.clientWidth, canvas.clientHeight);
-    }
-
-    /** Draw frame */
-    this._frameCallback();
-};
-
-/**
- * Clearing gl frame.
- * @public
- */
-Handler.prototype.clearFrame = function () {
-    var gl = this.gl;
-    this.gl.clearColor(0.0, 0.0, 0.0, 1.0);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-};
-
-/**
- * Starts animation loop.
- * @public
- */
-Handler.prototype.start = function () {
-    if (!this._requestAnimationFrameId && this._initialized) {
-        this._lastAnimationFrameTime = window.performance.now();
-        this.defaultClock.setDate(new Date());
-        this._animationFrameCallback();
-    }
-};
-
-Handler.prototype.stop = function () {
-    if (this._requestAnimationFrameId) {
-        window.cancelAnimationFrame(this._requestAnimationFrameId);
-        this._requestAnimationFrameId = null;
-    }
-};
-
-/**
- * Make animation.
- * @private
- */
-Handler.prototype._animationFrameCallback = function () {
-    this._requestAnimationFrameId = window.requestAnimationFrame(() => {
-        this.drawFrame();
-        this._animationFrameCallback();
-    });
-};
-
-/**
- * Creates default texture object
- * @public
- * @param {Object} [params] - Texture parameters:
- * @param {Array.<number, number, number, number>} [params.color] - Texture RGBA color
- * @param {number} [params.url] - Texture source url
- * @param {callback} success - Creation callback
- */
-Handler.prototype.createDefaultTexture = function (params, success) {
-    var imgCnv;
-    var texture;
-    if (params && params.color) {
-        imgCnv = new ImageCanvas(2, 2);
-        imgCnv.fillColor(params.color);
-        texture = this.createTexture_n(imgCnv._canvas);
-        texture.default = true;
-        success(texture);
-    } else if (params && params.url) {
-        var img = new Image();
+    /**
+     * Sets default gl render parameters. Used in init function.
+     * @private
+     */
+    _setDefaults = function () {
+        this.activateDepthTest();
+        this.setSize(this.canvas.clientWidth || this._params.width, this.canvas.clientHeight || this._params.height);
+        this.gl.frontFace(this.gl.CCW);
+        this.gl.cullFace(this.gl.BACK);
+        this.activateFaceCulling();
+        this.deactivateBlending();
         var that = this;
-        img.onload = function () {
-            texture = that.createTexture(this);
+        this.createDefaultTexture({ color: "rgba(0,0,0,0.0)" }, function (t) {
+            that.transparentTexture = t;
+        });
+    };
+
+    /**
+     * Activate depth test.
+     * @public
+     */
+    activateDepthTest = function () {
+        this.gl.enable(this.gl.DEPTH_TEST);
+    };
+
+    /**
+     * Deactivate depth test.
+     * @public
+     */
+    deactivateDepthTest = function () {
+        this.gl.disable(this.gl.DEPTH_TEST);
+    };
+
+    /**
+     * Activate face culling.
+     * @public
+     */
+    activateFaceCulling = function () {
+        this.gl.enable(this.gl.CULL_FACE);
+    };
+
+    /**
+     * Deactivate face cullting.
+     * @public
+     */
+    deactivateFaceCulling = function () {
+        this.gl.disable(this.gl.CULL_FACE);
+    };
+
+    /**
+     * Activate blending.
+     * @public
+     */
+    activateBlending = function () {
+        this.gl.enable(this.gl.BLEND);
+    };
+
+    /**
+     * Deactivate blending.
+     * @public
+     */
+    deactivateBlending = function () {
+        this.gl.disable(this.gl.BLEND);
+    };
+
+    /**
+     * Creates STREAM_DRAW ARRAY buffer.
+     * @public
+     * @param {Array.<number>} array - Input array.
+     * @param {number} itemSize - Array item size.
+     * @param {number} numItems - Items quantity.
+     * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
+     * @return {Object} -
+     */
+    createStreamArrayBuffer = function (itemSize, numItems, usage, bites = 4) {
+        var buffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, numItems * itemSize * bites, usage || this.gl.STREAM_DRAW);
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
+        buffer.itemSize = itemSize;
+        buffer.numItems = numItems;
+        return buffer;
+    };
+
+    /**
+     * Load stream ARRAY buffer.
+     * @public
+     * @param {Array.<number>} array - Input array.
+     * @param {number} itemSize - Array item size.
+     * @param {number} numItems - Items quantity.
+     * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
+     * @return {Object} -
+     */
+    setStreamArrayBuffer = function (buffer, array, offset = 0) {
+        let gl = this.gl;
+        gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
+        gl.bufferSubData(this.gl.ARRAY_BUFFER, offset, array);
+        gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
+        return buffer;
+    };
+
+    /**
+     * Creates ARRAY buffer.
+     * @public
+     * @param {Array.<number>} array - Input array.
+     * @param {number} itemSize - Array item size.
+     * @param {number} numItems - Items quantity.
+     * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
+     * @return {Object} -
+     */
+    createArrayBuffer = function (array, itemSize, numItems, usage) {
+        var buffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, buffer);
+        this.gl.bufferData(this.gl.ARRAY_BUFFER, array, usage || this.gl.STATIC_DRAW);
+        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, null);
+        buffer.itemSize = itemSize;
+        buffer.numItems = numItems;
+        return buffer;
+    };
+
+    /**
+     * Creates ELEMENT ARRAY buffer.
+     * @public
+     * @param {Array.<number>} array - Input array.
+     * @param {number} itemSize - Array item size.
+     * @param {number} numItems - Items quantity.
+     * @param {number} [usage=STATIC_DRAW] - Parameter of the bufferData call can be one of STATIC_DRAW, DYNAMIC_DRAW, or STREAM_DRAW.
+     * @return {Object} -
+     */
+    createElementArrayBuffer = function (array, itemSize, numItems, usage) {
+        var buffer = this.gl.createBuffer();
+        this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, buffer);
+        this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, array, usage || this.gl.STATIC_DRAW);
+        this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, null);
+        buffer.itemSize = itemSize;
+        buffer.numItems = numItems || array.length;
+        return buffer;
+    };
+
+    /**
+     * Sets handler canvas size.
+     * @public
+     * @param {number} w - Canvas width.
+     * @param {number} h - Canvas height.
+     */
+    setSize = function (w, h) {
+
+        if (w > MAX_SIZE) {
+            w = MAX_SIZE;
+        }
+
+        if (h > MAX_SIZE) {
+            h = MAX_SIZE;
+        }
+
+        this._params.width = w;
+        this._params.height = h;
+        this.canvas.width = w;
+        this.canvas.height = h;
+        this._oneByHeight = 1 / h;
+
+        this.gl && this.gl.viewport(0, 0, w, h);
+        this.onCanvasResize && this.onCanvasResize(this.canvas);
+    };
+
+    /**
+     * Returns context screen width.
+     * @public
+     * @returns {number} -
+     */
+    getWidth = function () {
+        return this.canvas.width;
+    };
+
+    /**
+     * Returns context screen height.
+     * @public
+     * @returns {number} -
+     */
+    getHeight = function () {
+        return this.canvas.height;
+    };
+
+    /**
+     * Returns canvas aspect ratio.
+     * @public
+     * @returns {number} -
+     */
+    getClientAspect = function () {
+        return this.canvas.clientWidth / this.canvas.clientHeight;
+    };
+
+    /**
+     * Returns screen center coordinates.
+     * @public
+     * @returns {number} -
+     */
+    getCenter = function () {
+        var c = this.canvas;
+        return new Vec2(Math.round(c.width * 0.5), Math.round(c.height * 0.5));
+    };
+
+    /**
+     * Draw single frame.
+     * @public
+     * @param {number} now - Frame current time milliseconds.
+     */
+    drawFrame = function () {
+
+        /** Calculating frame time */
+        var now = window.performance.now();
+        this.deltaTime = now - this._lastAnimationFrameTime;
+        this._lastAnimationFrameTime = now;
+
+        this.defaultClock._tick(this.deltaTime);
+
+        for (var i = 0; i < this._clocks.length; i++) {
+            this._clocks[i]._tick(this.deltaTime);
+        }
+
+        /** Canvas resize checking */
+        var canvas = this.canvas;
+        if (canvas.clientWidth !== canvas.width ||
+            canvas.clientHeight !== canvas.height) {
+            this.setSize(canvas.clientWidth, canvas.clientHeight);
+        }
+
+        /** Draw frame */
+        this._frameCallback();
+    };
+
+    /**
+     * Clearing gl frame.
+     * @public
+     */
+    clearFrame = function () {
+        var gl = this.gl;
+        this.gl.clearColor(0.0, 0.0, 0.0, 1.0);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    };
+
+    /**
+     * Starts animation loop.
+     * @public
+     */
+    start = function () {
+        if (!this._requestAnimationFrameId && this._initialized) {
+            this._lastAnimationFrameTime = window.performance.now();
+            this.defaultClock.setDate(new Date());
+            this._animationFrameCallback();
+        }
+    };
+
+    stop = function () {
+        if (this._requestAnimationFrameId) {
+            window.cancelAnimationFrame(this._requestAnimationFrameId);
+            this._requestAnimationFrameId = null;
+        }
+    };
+
+    /**
+     * Make animation.
+     * @private
+     */
+    _animationFrameCallback = function () {
+        this._requestAnimationFrameId = window.requestAnimationFrame(() => {
+            this.drawFrame();
+            this._animationFrameCallback();
+        });
+    };
+
+    /**
+     * Creates default texture object
+     * @public
+     * @param {Object} [params] - Texture parameters:
+     * @param {Array.<number, number, number, number>} [params.color] - Texture RGBA color
+     * @param {number} [params.url] - Texture source url
+     * @param {callback} success - Creation callback
+     */
+    createDefaultTexture = function (params, success) {
+        var imgCnv;
+        var texture;
+        if (params && params.color) {
+            imgCnv = new ImageCanvas(2, 2);
+            imgCnv.fillColor(params.color);
+            texture = this.createTexture_n(imgCnv._canvas);
             texture.default = true;
             success(texture);
-        };
-        img.src = params.url;
-    } else {
-        imgCnv = new ImageCanvas(2, 2);
-        imgCnv.fillColor("#C5C5C5");
-        texture = this.createTexture_n(imgCnv._canvas);
-        texture.default = true;
-        success(texture);
-    }
-};
+        } else if (params && params.url) {
+            var img = new Image();
+            var that = this;
+            img.onload = function () {
+                texture = that.createTexture(this);
+                texture.default = true;
+                success(texture);
+            };
+            img.src = params.url;
+        } else {
+            imgCnv = new ImageCanvas(2, 2);
+            imgCnv.fillColor("#C5C5C5");
+            texture = this.createTexture_n(imgCnv._canvas);
+            texture.default = true;
+            success(texture);
+        }
+    };
 
-/**
- * @public
- */
-Handler.prototype.destroy = function () {
+    /**
+     * @public
+     */
+    destroy = function () {
 
-    var gl = this.gl;
+        var gl = this.gl;
 
-    this.stop();
+        this.stop();
 
-    for (var p in this.programs) {
-        this.removeProgram(p);
-    }
+        for (var p in this.programs) {
+            this.removeProgram(p);
+        }
 
-    gl.deleteTexture(this.transparentTexture);
-    this.transparentTexture = null;
+        gl.deleteTexture(this.transparentTexture);
+        this.transparentTexture = null;
 
-    this.framebufferStack = null;
-    this.framebufferStack = new Stack();
+        this.framebufferStack = null;
+        this.framebufferStack = new Stack();
 
-    if (this.canvas.parentNode) {
-        this.canvas.parentNode.removeChild(this.canvas);
-    }
-    this.canvas.width = 1;
-    this.canvas.height = 1;
-    this.canvas = null;
+        if (this.canvas.parentNode) {
+            this.canvas.parentNode.removeChild(this.canvas);
+        }
+        this.canvas.width = 1;
+        this.canvas.height = 1;
+        this.canvas = null;
 
-    var numAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
-    var tmp = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, tmp);
-    for (let ii = 0; ii < numAttribs; ++ii) {
-        gl.disableVertexAttribArray(ii);
-        gl.vertexAttribPointer(ii, 4, gl.FLOAT, false, 0, 0);
-        gl.vertexAttrib1f(ii, 0);
-    }
-    gl.deleteBuffer(tmp);
+        var numAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+        var tmp = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, tmp);
+        for (let ii = 0; ii < numAttribs; ++ii) {
+            gl.disableVertexAttribArray(ii);
+            gl.vertexAttribPointer(ii, 4, gl.FLOAT, false, 0, 0);
+            gl.vertexAttrib1f(ii, 0);
+        }
+        gl.deleteBuffer(tmp);
 
-    var numTextureUnits = gl.getParameter(gl.MAX_TEXTlURE_IMAGE_UNITS);
-    for (let ii = 0; ii < numTextureUnits; ++ii) {
-        gl.activeTexture(gl.TEXTURE0 + ii);
-        gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
-        gl.bindTexture(gl.TEXTURE_2D, null);
-    }
+        var numTextureUnits = gl.getParameter(gl.MAX_TEXTlURE_IMAGE_UNITS);
+        for (let ii = 0; ii < numTextureUnits; ++ii) {
+            gl.activeTexture(gl.TEXTURE0 + ii);
+            gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
+            gl.bindTexture(gl.TEXTURE_2D, null);
+        }
 
-    gl.activeTexture(gl.TEXTURE0);
-    gl.useProgram(null);
-    gl.bindBuffer(gl.ARRAY_BUFFER, null);
-    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    gl.bindRenderbuffer(gl.RENDERBUFFER, null);
-    gl.disable(gl.BLEND);
-    gl.disable(gl.CULL_FACE);
-    gl.disable(gl.DEPTH_TEST);
-    gl.disable(gl.DITHER);
-    gl.disable(gl.SCISSOR_TEST);
-    gl.blendColor(0, 0, 0, 0);
-    gl.blendEquation(gl.FUNC_ADD);
-    gl.blendFunc(gl.ONE, gl.ZERO);
-    gl.clearColor(0, 0, 0, 0);
-    gl.clearDepth(1);
-    gl.clearStencil(-1);
+        gl.activeTexture(gl.TEXTURE0);
+        gl.useProgram(null);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+        gl.disable(gl.BLEND);
+        gl.disable(gl.CULL_FACE);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.DITHER);
+        gl.disable(gl.SCISSOR_TEST);
+        gl.blendColor(0, 0, 0, 0);
+        gl.blendEquation(gl.FUNC_ADD);
+        gl.blendFunc(gl.ONE, gl.ZERO);
+        gl.clearColor(0, 0, 0, 0);
+        gl.clearDepth(1);
+        gl.clearStencil(-1);
 
-    this.gl = null;
+        this.gl = null;
 
-    this._initialized = false;
-};
+        this._initialized = false;
+    };
 
-Handler.prototype.addClock = function (clock) {
-    if (!clock.__handler) {
-        clock.__handler = this;
-        this._clocks.push(clock);
-    }
-};
+    addClock = function (clock) {
+        if (!clock.__handler) {
+            clock.__handler = this;
+            this._clocks.push(clock);
+        }
+    };
 
-Handler.prototype.addClocks = function (clockArr) {
-    for (var i = 0; i < clockArr.length; i++) {
-        this.addClock(clockArr[i]);
-    }
-};
+    addClocks = function (clockArr) {
+        for (var i = 0; i < clockArr.length; i++) {
+            this.addClock(clockArr[i]);
+        }
+    };
 
-Handler.prototype.removeClock = function (clock) {
-    if (clock.__handler) {
-        var c = this._clocks;
-        var i = c.length;
-        while (i--) {
-            if (c[i].equal(clock)) {
-                clock.__handler = null;
-                c.splice(i, 1);
-                break;
+    removeClock = function (clock) {
+        if (clock.__handler) {
+            var c = this._clocks;
+            var i = c.length;
+            while (i--) {
+                if (c[i].equal(clock)) {
+                    clock.__handler = null;
+                    c.splice(i, 1);
+                    break;
+                }
             }
         }
-    }
-};
-
-export { Handler };
+    };
+}


### PR DESCRIPTION
Refactor to use the `class` syntax instead of a javascript variable with `prototype` syntax.

2 reasons:
1/ generate `@types`. It doesn't work with the `prototype` syntax.
2/ to be consistent with the rest of the code.