### PR TITLE
array number fix

### DIFF
--- a/src/og/Extent.js
+++ b/src/og/Extent.js
@@ -48,7 +48,7 @@ export class Extent {
     /**
      * Creates extent instance from values in array.
      * @static
-     * @param {Array.<number,number,number,number>} arr - South west and north east longitude and latidudes packed in array.
+     * @param {Array.<number>} arr - South west and north east longitude and latidudes packed in array. (exactly 4 entries)
      * @return {og.Extent} Extent object.
      */
     static createFromArray(arr) {

--- a/src/og/LonLat.js
+++ b/src/og/LonLat.js
@@ -52,7 +52,7 @@ export class LonLat {
     /**
      * Creates coordinates array.
      * @static
-     * @param{Array.<Array<number,number,number>>} arr - Coordinates array data.
+     * @param{Array.<Array<number>>} arr - Coordinates array data. (exactly 3 entries)
      * @return{Array.<og.LonLat>} the same coordinates array but each element is LonLat instance.
      */
     static join(arr) {
@@ -67,7 +67,7 @@ export class LonLat {
     /**
      * Creates an object by coordinate array.
      * @static
-     * @param {Array.<number,number,number>} arr - Coordiante array, where first is longitude, second is latitude and third is a height.
+     * @param {Array.<number>} arr - Coordiante array, where first is longitude, second is latitude and third is a height. (exactly 3 entries)
      * @returns {og.LonLat} -
      */
     static createFromArray(arr) {

--- a/src/og/entity/EntityCollection.js
+++ b/src/og/entity/EntityCollection.js
@@ -21,7 +21,7 @@ import { ShapeHandler } from './ShapeHandler.js';
  * @param {Object} [options] - Entity options:
  * @param {Array.<og.Entity>} [options.entities] - Entities array.
  * @param {boolean} [options.visibility=true] - Entity visibility.
- * @param {Array.<number,number,number>} [options.scaleByDistance] - Entity scale by distance parameters.
+ * @param {Array.<number>} [options.scaleByDistance] - Entity scale by distance parameters. (exactly 3 entries)
  * First index - near distance to the entity, after entity becomes full scale.
  * Second index - far distance to the entity, when entity becomes zero scale.
  * Third index - far distance to the entity, when entity becomes invisible.


### PR DESCRIPTION
When I try to generate the types for the project I get a error with this annotation:
```
@param {Array.<number,number,number>} comment goes here
```

It's not a standard annotation: https://stackoverflow.com/questions/22786245/jsdoc-how-to-specify-array-length

The following annotation would work but breaks jsdoc.
```
@param {[number,number,number]} comment goes here
```

Maybe we can use this to please jsdoc and types generation?
```
@param {Array.<number>} comment goes here (exactly 3 entries)
```
I give an example of what it can look like in this PR.
