### PR TITLE
publish system improvement 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "directories": {
     "example": "./sandbox"
   },
-  "main": "./src/og/index.js",
-  "style": "./css/og.css",
+  "main": "index.js",
+  "style": "og.css",
   "types": "./types/index.d.ts",
   "scripts": {
     "api": "jsdoc -t ./jsdoc -r ./src/ -c ./jsdoc/conf.json -d ./api",

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,13 @@
+rm -rf dist api coverage types
+npm run build
+npm run generate_types
+mkdir dist/publish
+cp -r types dist/publish/
+cp package.json dist/publish/
+cp LICENSE.md dist/publish/
+cp README.md dist/publish/
+cp css/og.css dist/publish/
+cp dist/@openglobus/og.esm.js dist/publish/index.js
+cd dist/publish
+npm publish --dry-run
+cd ../..


### PR DESCRIPTION
This is not tested so I'm not fully sure it's what we want.

Currently the sources are published to npmjs.com and not the compiled version. It causes flakiness when we use KMLs. I think we should use the esm build instead.

It also add the types in the `types` folder declared in `package.json`