### PR TITLE
fix travis build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "api": "jsdoc -t ./jsdoc -r ./src/ -c ./jsdoc/conf.json -d ./api",
     "serve": "ws",
     "build": "rollup -c",
-    "postbuild": "npm run generate_types",
     "webgl": "rollup -c --environment entry:webgl",
     "core": "rollup -c --environment entry:core",
     "test": "jest --env=jsdom",


### PR DESCRIPTION
`.travis.yml:12` wants to build and postbuild before pushing the zip file to github.
The postbuild is the types generation which fails because I have not finish the migration to es6 classes yet.

I remove the types from the zip file for now. Till I'm done with the es6 migration.