### PR TITLE
[462] add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+api
+coverage


### PR DESCRIPTION
when running `npm publish` npm excludes what is in `.gitignore`.
To change that, create a `.npmignore` with what to ignore.

#### **Verify that...**

- [x] `npm test` passes
- [x] `npm run api` passes
- [x] `npm run lint` passes
- [x] `npm run build` still works

