### PR TITLE
fix one finger ontouchmove swipe map error drift

### DIFF
--- a/src/og/control/TouchNavigation.js
+++ b/src/og/control/TouchNavigation.js
@@ -119,7 +119,7 @@ class TouchNavigation extends Control {
         t.prev_x = e.sys.touches.item(0).clientX - e.sys.offsetLeft;
         t.prev_y = e.sys.touches.item(0).clientY - e.sys.offsetTop;
 
-        t.grabbedPoint = this.planet.getCartesianFromPixelTerrain(t, true);
+        t.grabbedPoint = this.planet.getCartesianFromPixelTerrain(e, true);
         this._eye0.copy(this.renderer.activeCamera.eye);
 
         if (t.grabbedPoint) {
@@ -142,13 +142,8 @@ class TouchNavigation extends Control {
 
         this.planet.stopFlying();
         this.stopRotation();
-        
-        let h = this.renderer.handler;
-        var touchCoordinate = {
-            x: this.touches[0].x * h.pixelRatio,
-            y: this.touches[0].y * h.pixelRatio
-        }
-        var p = this.planet.getCartesianFromPixelTerrain(touchCoordinate);
+
+        var p = this.planet.getCartesianFromPixelTerrain(e);
         if (p) {
             var g = this.planet.ellipsoid.cartesianToLonLat(p);
             this.planet.flyLonLat(
@@ -252,7 +247,7 @@ class TouchNavigation extends Control {
 
             this.planet.stopFlying();
 
-            var direction = cam.unproject(t.x, t.y);
+            var direction = e.direction
             var targetPoint = new Ray(cam.eye, direction).hitSphere(t.grabbedSpheroid);
 
             if (targetPoint) {

--- a/src/og/renderer/RendererEvents.js
+++ b/src/og/renderer/RendererEvents.js
@@ -161,6 +161,8 @@ class RendererEvents extends Events {
             prev_x: 0,
             /** Previous touch Y coordinate. */
             prev_y: 0,
+            /** Screen mouse position world direction. */
+            direction: new Vec3(),
             /** JavaScript touching system event message. */
             sys: null,
             /** Current touched(picking) object. */
@@ -221,6 +223,10 @@ class RendererEvents extends Events {
             this.mouseState.direction = this.renderer.activeCamera.unproject(
                 this.mouseState.x,
                 this.mouseState.y
+            );
+            this.touchState.direction = this.renderer.activeCamera.unproject(
+                this.touchState.x,
+                this.touchState.y
             );
             this.entityPickingEvents();
             this._keyboardHandler.handleEvents();

--- a/src/og/renderer/RendererEvents.js
+++ b/src/og/renderer/RendererEvents.js
@@ -161,7 +161,7 @@ class RendererEvents extends Events {
             prev_x: 0,
             /** Previous touch Y coordinate. */
             prev_y: 0,
-            /** Screen mouse position world direction. */
+            /** Screen touch position world direction. */
             direction: new Vec3(),
             /** JavaScript touching system event message. */
             sys: null,


### PR DESCRIPTION
INSERT A SMALL DESCRIPTION OF WHAT YOU CHANGED HERE

Fixed, in touch screen, in the case of low zoom level, touch and slide the outer part of the globe (universe), the globe will rotate incorrectly.

#### **Verify that...**

- [x] `npm test` passes
- [x] `npm run api` passes
- [ ] `npm run lint` passes

  C:\work\repo\openglobus\src\og\layer\KML.js
  121:18  error  Unnecessary semicolon  no-extra-semi
  128:22  error  Unnecessary semicolon  no-extra-semi
  129:18  error  Unnecessary semicolon  no-extra-semi
  130:14  error  Unnecessary semicolon  no-extra-semi
  140:14  error  Unnecessary semicolon  no-extra-semi
  141:10  error  Unnecessary semicolon  no-extra-semi
  174:14  error  Unnecessary semicolon  no-extra-semi
  175:10  error  Unnecessary semicolon  no-extra-semi
  224:10  error  Unnecessary semicolon  no-extra-semi
  243:10  error  Unnecessary semicolon  no-extra-semi
  345:67  error  'kml' is not defined   no-undef

✖ 11 problems (11 errors, 0 warnings)
  10 errors and 0 warnings potentially fixable with the `--fix` option.

- [x] `npm run build` still works

