### PR TITLE
#609 Add extra vendor parameters to WMS request

### DIFF
--- a/src/og/layer/WMS.js
+++ b/src/og/layer/WMS.js
@@ -48,7 +48,7 @@ import { XYZ } from "./XYZ.js";
 class WMS extends XYZ {
 
 
-    constructor(name, options,extra ) {
+    constructor(name, options, extra) {
         super(name, options);
 
         this.extra = new URLSearchParams(extra).toString();

--- a/src/og/layer/WMS.js
+++ b/src/og/layer/WMS.js
@@ -27,6 +27,7 @@ import { XYZ } from "./XYZ.js";
  * @param {number} [options.height=256] - Tile height.
  * @param {string} options.layers - WMS layers string.
  * @param {string} [options.version="1.1.1"] - WMS version.
+ * @param {Object} extra  - Extra parameters (by WMS rreference or by WMS service vendors) to pass to WMS service.
  * @example:
  * new og.layer.WMS("USA States", {
  *     isBaseLayer: false,
@@ -36,20 +37,30 @@ import { XYZ } from "./XYZ.js";
  *     zIndex: 50,
  *     attribution: 'USA states - geoserver WMS example',
  *     version: "1.1.1",
- *     visibility: false }
+ *     visibility: false }, {
+ *     transparent: true,
+ *     sld: "style.sld"}	   
  * );
  *
  * @fires og.layer.XYZ#load
  * @fires og.layer.XYZ#loadend
  */
 class WMS extends XYZ {
-    constructor(name, options) {
+
+
+    constructor(name, options,extra ) {
         super(name, options);
+
+	this.extra = new URLSearchParams(extra).toString();
+
 
         if (!options.extent) {
             this.setExtent(new Extent(new LonLat(-180.0, -90), new LonLat(180.0, 90)));
         }
 
+	if (options.srid){
+		this.srid = options.srid;
+	}
         /**
          * WMS layers string.
          * @public
@@ -85,10 +96,12 @@ class WMS extends XYZ {
         srs,
         bbox,
         width = 256,
-        height = 256
+        height = 256,
+	extra
+
     ) {
         return `${url}/wms?LAYERS=${layers}&FORMAT=${format}&SERVICE=WMS&VERSION=${version}&REQUEST=${request}
-        &SRS=${srs}&BBOX=${bbox}&WIDTH=${width}&HEIGHT=${height}`;
+        &SRS=${srs}&BBOX=${bbox}&WIDTH=${width}&HEIGHT=${height}&` + extra;
     }
 
     static get_bbox_v1_1_1(extent) {
@@ -130,10 +143,11 @@ class WMS extends XYZ {
             "image/png",
             this._version,
             "GetMap",
-            segment._projection.code,
+            this.srid?this.srid:segment._projection.code,
             this._getBbox(segment.getExtent()),
             this.imageWidth,
-            this.imageHeight
+            this.imageHeight,
+            this.extra
         );
     }
 

--- a/src/og/layer/WMS.js
+++ b/src/og/layer/WMS.js
@@ -51,7 +51,7 @@ class WMS extends XYZ {
     constructor(name, options,extra ) {
         super(name, options);
 
-	this.extra = new URLSearchParams(extra).toString();
+        this.extra = new URLSearchParams(extra).toString();
 
 
         if (!options.extent) {
@@ -94,7 +94,7 @@ class WMS extends XYZ {
         bbox,
         width = 256,
         height = 256,
-	extra
+        extra
 
     ) {
         return `${url}/wms?LAYERS=${layers}&FORMAT=${format}&SERVICE=WMS&VERSION=${version}&REQUEST=${request}

--- a/src/og/layer/WMS.js
+++ b/src/og/layer/WMS.js
@@ -58,9 +58,6 @@ class WMS extends XYZ {
             this.setExtent(new Extent(new LonLat(-180.0, -90), new LonLat(180.0, 90)));
         }
 
-	if (options.srid){
-		this.srid = options.srid;
-	}
         /**
          * WMS layers string.
          * @public
@@ -143,7 +140,7 @@ class WMS extends XYZ {
             "image/png",
             this._version,
             "GetMap",
-            this.srid?this.srid:segment._projection.code,
+            segment._projection.code,
             this._getBbox(segment.getExtent()),
             this.imageWidth,
             this.imageHeight,

--- a/src/og/layer/WMS.js
+++ b/src/og/layer/WMS.js
@@ -51,7 +51,7 @@ class WMS extends XYZ {
     constructor(name, options, extra) {
         super(name, options);
 
-        this.extra = new URLSearchParams(extra).toString();
+        this._extra = new URLSearchParams(extra).toString();
 
 
         if (!options.extent) {
@@ -144,7 +144,7 @@ class WMS extends XYZ {
             this._getBbox(segment.getExtent()),
             this.imageWidth,
             this.imageHeight,
-            this.extra
+            this._extra
         );
     }
 


### PR DESCRIPTION
The WMS constructor includes a third parameter with further parameters to pass to WMS request as vendor parameters or simply wms options specified in OGC WMS reference not included into the second parameter called "Options".

#### **Verify that...**

- [x] `npm test` passes
- [x] `npm run api` passes
- [x] `npm run lint` passes
- [x] `npm run build` still works

