### PR TITLE
Add Object3d to module exports

### DIFF
--- a/examples/animatedLayer/animatedLayer.html
+++ b/examples/animatedLayer/animatedLayer.html
@@ -1,0 +1,102 @@
+<html>
+
+<head>
+    <title>OpenGlobus - Earth planet</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../css/og.css" type="text/css" />
+</head>
+
+<body>
+    <div id="globus" style="width:100%;height:100%"></div>
+    <script type="module">
+
+        'use strict';
+
+        import { Globe } from '../../src/og/Globe.js';
+        import { EmptyTerrain } from '../../src/og/terrain/EmptyTerrain.js';
+        import { XYZ } from '../../src/og/layer/XYZ.js';
+        import { CanvasTiles } from '../../src/og/layer/CanvasTiles.js';
+        import { ToggleWireframe } from '../../src/og/control/ToggleWireframe.js';
+        import { ShowFps } from '../../src/og/control/ShowFps.js';
+        import { SegmentLonLat } from '../../src/og/segment/SegmentLonLat.js';
+
+        const osm = new XYZ("OSM", {
+            'specular': [0.0003, 0.00012, 0.00001],
+            'shininess': 20,
+            'diffuse': [0.89, 0.9, 0.83],
+            'isBaseLayer': true,
+            'url': "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            'visibility': true,
+            'attribution': 'Data @ OpenStreetMap contributors, ODbL'
+        });
+
+        let frameid = 0;
+
+        // We just create one canvas and reuse it everywhere, that way
+        // we don't end up having millions of canvases that need to be
+        // garbage collected.
+        // 
+        // That said, this is a bad demo in some ways because it will
+        // become progressively slower over time as more old
+        // textures need to be garbage collected, instead of them being
+        // reused internally. Also, drawing with Canvas is pretty slow.
+        // 
+        let cnv = document.createElement("canvas");
+        let ctx = cnv.getContext("2d");
+        cnv.width = 256;
+        cnv.height = 256;
+
+        const tg = new CanvasTiles("Tile grid", {
+            visibility: true,
+            isBaseLayer: false,
+            animated: true,
+            drawTile: function (material, applyCanvas) {
+
+                //Clear canvas
+                ctx.clearRect(0, 0, cnv.width, cnv.height);
+
+                //Draw border
+                ctx.beginPath();
+                ctx.rect(0, 0, cnv.width, cnv.height);
+                ctx.lineWidth = 2;
+                ctx.strokeStyle = 'black';
+                ctx.stroke();
+
+                let size;
+
+                if (material.segment.isPole) {
+                } else {
+                    //Draw text
+                    if (material.segment.tileZoom > 14) {
+                        size = "26";
+                    } else {
+                        size = "32";
+                    }
+                    ctx.fillStyle = 'black';
+                    ctx.font = 'normal ' + size + 'px Verdana';
+                    ctx.textAlign = 'center';
+                    frameid++;
+                    ctx.fillText(frameid + ";" + material.segment.tileX + "," + material.segment.tileY + "," + material.segment.tileZoom, cnv.width / 2, cnv.height / 2);
+                }
+
+                //Draw canvas tile
+                applyCanvas(cnv);
+            }
+        });
+
+        window.globe = new Globe({
+            'name': "Earth",
+            'target': "globus",
+            'terrain': new EmptyTerrain(),
+            'layers': [osm, tg],
+            "sun": {
+                "active": false
+            }
+        });
+
+        window.globe.planet.addControl(new ShowFps());
+        window.globe.planet.addControl(new ToggleWireframe());
+    </script>
+</body>
+
+</html>

--- a/src/og/index.js
+++ b/src/og/index.js
@@ -24,6 +24,7 @@ import { Ellipsoid, wgs84 } from './ellipsoid/index.js';
 import { Camera, PlanetCamera } from './camera/index.js';
 
 import { Line2, Line3, Mat3, Mat4, Plane, Quat, Ray, Vec2, Vec3, Vec4 } from './math/index.js';
+import { Object3d } from './Object3d.js';
 
 import { Renderer } from './renderer/Renderer.js';
 
@@ -99,6 +100,7 @@ export {
     Vec2,
     Vec3,
     Vec4,
+    Object3d,
     entity,
     Entity,
     Geoid,
@@ -107,5 +109,5 @@ export {
     MarsQuadTreeStrategy,
     EarthQuadTreeStrategy,
     Wgs84QuadTreeStrategy,
-    quadTreeStrategyType
+    quadTreeStrategyType,
 };

--- a/src/og/layer/CanvasTiles.js
+++ b/src/og/layer/CanvasTiles.js
@@ -59,6 +59,11 @@ class CanvasTiles extends Layer {
         this._counter = 0;
 
         /**
+         * Whether to animate this tile layer
+         */
+        this._animated = options.animated || false;
+
+        /**
          * Tile pending queue that waiting for create.
          * @protected
          * @type {Array.<planetSegment.Material>}
@@ -241,6 +246,20 @@ class CanvasTiles extends Layer {
             }
         }
         return null;
+    }
+
+    drawAnimationFrame(material) {
+        if (this.drawTile) {
+            const that = this;
+            requestAnimationFrame(() => {
+                that.drawTile(
+                    material,
+                    function (canvas) {
+                        material.applyImage(canvas);
+                    }
+                );
+            });
+        }
     }
 
     applyMaterial(material) {

--- a/src/og/layer/Layer.js
+++ b/src/og/layer/Layer.js
@@ -78,6 +78,8 @@ class Layer {
 
         this._hasImageryTiles = true;
 
+        this._animated = false;
+
         /**
          * Layer global opacity.
          * @public
@@ -708,6 +710,14 @@ class Layer {
 
     createMaterial(segment) {
         return new Material(segment, this);
+    }
+
+    frame() {
+        console.log("Rendering animations...")
+        // Only makes sense for animated layers.
+        if (this._planet) {
+            this._planet.quadTreeStrategy.redrawLayerMaterial(this);
+        }        
     }
 
     redraw() {

--- a/src/og/layer/Material.js
+++ b/src/og/layer/Material.js
@@ -98,6 +98,16 @@ class Material {
     }
 
     /**
+     * Called on each frame when rendering animated layers.
+     */
+    frame() {
+        if (!this.segment.initialized || !this.isReady || this.isLoading) return;
+        if (this.layer.drawAnimationFrame) {
+            this.layer.drawAnimationFrame(this);
+        }
+    }
+
+    /**
      *
      */
     clear() {

--- a/src/og/quadTree/QuadTreeStrategy.js
+++ b/src/og/quadTree/QuadTreeStrategy.js
@@ -1,5 +1,10 @@
 "use strict";
 import { EPSG3857 } from "../proj/EPSG3857.js";
+import {
+    NOTRENDERING,
+    RENDERING,
+    WALKTHROUGH
+} from "./quadTree.js";
 
 export class QuadTreeStrategy {
     constructor(options = {}) {
@@ -33,6 +38,19 @@ export class QuadTreeStrategy {
                 }
             });
         }
+    }
+
+    redrawLayerMaterial(layer) {
+        let lid = layer._id;
+        for (let i = 0, len = this._quadTreeList.length; i < len; i++) {
+            this._quadTreeList[i].traverseTree(function (node) {
+                if (node.state !== RENDERING) { return; }
+                let mats = node.segment.materials;
+                if (mats[lid]) {
+                    mats[lid].frame();
+                }
+            });
+        }        
     }
 
     get planet() {

--- a/src/og/scene/Planet.js
+++ b/src/og/scene/Planet.js
@@ -1073,6 +1073,8 @@ export class Planet extends RenderNode {
             this._updateVisibleLayers();
         }
 
+        this._renderAnimatedLayersPASS();
+
         this._renderScreenNodesPASS();
 
         this._renderHeightPickingFramebufferPASS();
@@ -1362,6 +1364,19 @@ export class Planet extends RenderNode {
             rn[i].segment.depthRendering(sh, sl[0]);
         }
     }
+
+    /**
+     * @protected
+     */
+    _renderAnimatedLayersPASS() {
+        for (let i = 0, len = this._layers.length; i < len; i++) {
+            let li = this._layers[i];
+            if (li._visibility && li._animated) {
+                li.frame();
+            }
+        }
+    }
+
 
     _collectVectorLayerCollections() {
         this._frustumEntityCollections.length = 0;


### PR DESCRIPTION
Making Object3d accessible from the module, so as to optionally expose the models within for external use.