### PR TITLE
Draft: #649 zoomOffset suggestion

### DIFF
--- a/sandbox/zoomOffset/zoomOffset.html
+++ b/sandbox/zoomOffset/zoomOffset.html
@@ -1,0 +1,112 @@
+<html>
+
+<head>
+    <title>OpenGlobus - Earth planet</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../../css/og.css" type="text/css" />
+</head>
+
+<body>
+    <label style="position: absolute; top: 10px; left: 10px; z-index: 10;">zoomOffset:
+        <input id="zoomOffset" type="number" min="-2" max="3" step="1" value="0">
+    </label>
+    <div id="globus" style="width:100%;height:100%"></div>
+    <script type="module">
+
+        'use strict';
+
+        import { Globe } from '../../src/og/Globe.js';
+        import { EmptyTerrain } from '../../src/og/terrain/EmptyTerrain.js';
+        import { XYZ } from '../../src/og/layer/XYZ.js';
+        import { CanvasTiles } from '../../src/og/layer/CanvasTiles.js';
+        import { ToggleWireframe } from '../../src/og/control/ToggleWireframe.js';
+        import { SegmentLonLat } from '../../src/og/segment/SegmentLonLat.js';
+
+        const osm = new XYZ("OSM", {
+            'specular': [0.0003, 0.00012, 0.00001],
+            'shininess': 20,
+            'diffuse': [0.89, 0.9, 0.83],
+            'isBaseLayer': true,
+            'url': "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            'visibility': true,
+            'attribution': 'Data @ OpenStreetMap contributors, ODbL'
+        });
+
+        const tg = new CanvasTiles("Tile grid", {
+            visibility: true,
+            isBaseLayer: false,
+            drawTile: function (material, applyCanvas) {
+
+                //
+                // This is important create canvas here!
+                //
+                let cnv = document.createElement("canvas");
+                let ctx = cnv.getContext("2d");
+                cnv.width = 256;
+                cnv.height = 256;
+
+                //Clear canvas
+                ctx.clearRect(0, 0, cnv.width, cnv.height);
+
+                //Draw border
+                ctx.beginPath();
+                ctx.rect(0, 0, cnv.width, cnv.height);
+                ctx.lineWidth = 2;
+                ctx.strokeStyle = 'black';
+                ctx.stroke();
+
+                let size;
+
+                if (material.segment.isPole) {
+                    let ext = material.segment.getExtentLonLat();
+
+                    ctx.fillStyle = 'black';
+                    ctx.font = 'normal ' + 29 + 'px Verdana';
+
+                    ctx.textAlign = 'center';
+                    ctx.fillText(`${ext.northEast.lon.toFixed(3)} ${ext.northEast.lat.toFixed(3)}`, cnv.width / 2, cnv.height / 2 + 20);
+                    ctx.fillText(`${ext.southWest.lon.toFixed(3)} ${ext.southWest.lat.toFixed(3)}`, cnv.width / 2, cnv.height / 2 - 20);
+                } else {
+                    //Draw text
+                    if (material.segment.tileZoom > 14) {
+                        size = "26";
+                    } else {
+                        size = "32";
+                    }
+                    ctx.fillStyle = 'black';
+                    ctx.font = 'normal ' + size + 'px Verdana';
+                    ctx.textAlign = 'center';
+                    ctx.fillText(material.segment.tileX + "," + material.segment.tileY + "," + material.segment.tileZoom, cnv.width / 2, cnv.height / 2);
+                }
+
+                //Draw canvas tile
+                applyCanvas(cnv);
+            }
+        });
+
+        window.globe = new Globe({
+            'name': "Earth",
+            'target': "globus",
+            'terrain': new EmptyTerrain(),
+            'layers': [osm, tg],
+            "sun": {
+                "active": false
+            },
+            "zoomOffset": 0,
+        });
+
+        window.globe.planet.addControl(new ToggleWireframe());
+
+        const updateZoomOffset = function () {
+            let zoomOffset = document.getElementById("zoomOffset").value;
+
+            // you wouldn't want to do it this way, zoomOffset is something you should only set on initialization
+            // this is for simply showing the effect of changing it in the demo
+            window.globe.planet._zoomOffset = zoomOffset;
+        };
+
+        document.getElementById("zoomOffset").addEventListener("change", updateZoomOffset);
+    </script>
+</body>
+
+</html>

--- a/src/og/Globe.js
+++ b/src/og/Globe.js
@@ -69,6 +69,7 @@ const PLANET_NAME_PREFIX = "globus_planet_";
  * @param {Number} [options.minEqualZoomCameraSlope=0.8] - Minimal camera slope above te globe where segments on the screen bacame the same zoom level
  * @param {Number} [options.loadingBatchSize=12] -
  * @param {Number} [options.quadTreeStrategyPrototype] - Prototype of quadTree. QuadTreeStrategy for Earth is default.
+ * @param {Number} [options.zoomOffset=0] - Number to offset the zoom level by a certain amount.
  */
 
 class Globe {
@@ -184,7 +185,8 @@ class Globe {
                 minEqualZoomAltitude: options.minEqualZoomAltitude,
                 minEqualZoomCameraSlope: options.minEqualZoomCameraSlope,
                 quadTreeStrategyPrototype: options.quadTreeStrategyPrototype,
-                maxLoadingRequests: options.maxLoadingRequests
+                maxLoadingRequests: options.maxLoadingRequests,
+                zoomOffset: options.zoomOffset,
             });
         }
 

--- a/src/og/quadTree/Node.js
+++ b/src/og/quadTree/Node.js
@@ -249,7 +249,7 @@ class Node {
 
             if (seg.tileZoom < 2 && seg.normalMapReady) {
                 this.traverseNodes(cam, maxZoom, terrainReadySegment, stopLoading);
-            } else if (seg.terrainReady && (!maxZoom && cam.projectedSize(seg.bsphere.center, seg._plainRadius) < planet._lodSize || maxZoom && ((seg.tileZoom === maxZoom) || !altVis))) {
+            } else if (seg.terrainReady && (!maxZoom && cam.projectedSize(seg.bsphere.center, seg._plainRadius) < planet._lodSize / Math.pow(2, planet._zoomOffset) || maxZoom && ((seg.tileZoom === maxZoom) || !altVis))) {
 
                 if (altVis) {
                     seg.passReady = true;

--- a/src/og/scene/Planet.js
+++ b/src/og/scene/Planet.js
@@ -108,6 +108,7 @@ const EVENT_NAMES = [/**
  * @param {Number} [options.maxEqualZoomAltitude=15000000.0] - Maximal altitude since segments on the screen bacame the same zoom level
  * @param {Number} [options.minEqualZoomAltitude=10000.0] - Minimal altitude since segments on the screen bacame the same zoom level
  * @param {Number} [options.minEqualZoomCameraSlope=0.8] - Minimal camera slope above te globe where segments on the screen bacame the same zoom level
+ * @param {Number} [options.zoomOffset=0] - Number to offset the zoom level by a certain amount.
  * @fires og.scene.Planet#draw
  * @fires og.scene.Planet#layeradd
  * @fires og.scene.Planet#baselayerchange
@@ -119,6 +120,7 @@ export class Planet extends RenderNode {
     constructor(options = {}) {
         super(options.name);
 
+        this._zoomOffset = options.zoomOffset || 0;
         this._cameraFrustums = options.frustums || [[1, 100 + 0.075], [100, 1000 + 0.075], [1000, 1e6 + 10000], [1e6, 1e9]];
 
         /**


### PR DESCRIPTION
A suggestion to add a tile zoom offset as described in discussion #634  

i found that in the [Node component of the quadTree, at line 252](https://github.com/openglobus/openglobus/blob/master/src/og/quadTree/Node.js#L252) the size of the node is compared to the lodSize. This determines whether the node is rendered, or traversed further. By adding a zoomOffset parameter and manipulating this comparison, the desired result is achieved.

npm test passes
npm run api passes
npm run lint passes
npm run build still works