### PR TITLE
typescript doesn't like the super calls

### DIFF
--- a/src/layer/BaseGeoImage.ts
+++ b/src/layer/BaseGeoImage.ts
@@ -131,7 +131,7 @@ class BaseGeoImage extends Layer {
     }
 
     public override get isIdle(): boolean {
-        return super.isIdle && this._ready;
+        return !!this._planet && this._planet._terrainCompletedActivated && this._ready;
     }
 
     public override addTo(planet: Planet) {

--- a/src/layer/CanvasTiles.ts
+++ b/src/layer/CanvasTiles.ts
@@ -131,7 +131,7 @@ class CanvasTiles extends Layer {
     }
 
     public override get isIdle() {
-        return super.isIdle && this._counter === 0;
+        return !!this._planet && this._planet._terrainCompletedActivated && this._counter === 0;
     }
 
     /**

--- a/src/layer/Layer.ts
+++ b/src/layer/Layer.ts
@@ -492,7 +492,7 @@ class Layer {
     }
 
     public get isIdle(): boolean {
-        return this._planet && this._planet._terrainCompletedActivated || false;
+        return !!this._planet && this._planet._terrainCompletedActivated;
     }
 
     /**


### PR DESCRIPTION
The default React configuration doesn't like the `super` syntax. I'm not sure how to fix this.

https://stackoverflow.com/questions/50283360/typescript-error-ts2340-public-methods-accessible-via-super-keyword