### PR TITLE
Fix WMS: remove trailing slash

### DIFF
--- a/src/layer/WMS.ts
+++ b/src/layer/WMS.ts
@@ -118,7 +118,7 @@ class WMS extends XYZ {
         height: number = 256,
         extra?: string
     ): string {
-        return `${url}/?LAYERS=${layers}&FORMAT=${format}&SERVICE=WMS&VERSION=${version}&REQUEST=${request}&SRS=${srs}&BBOX=${bbox}&WIDTH=${width}&HEIGHT=${height}` + (extra ? `&${extra}` : "");
+        return `${url}?LAYERS=${layers}&FORMAT=${format}&SERVICE=WMS&VERSION=${version}&REQUEST=${request}&SRS=${srs}&BBOX=${bbox}&WIDTH=${width}&HEIGHT=${height}` + (extra ? `&${extra}` : "");
     }
 
     static get_bbox_v1_1_1(extent: Extent): string {


### PR DESCRIPTION
This PR removes a hardcoded trailing slash after the url of a WMS service. This trailing slash can cause issues for servers with strict routing behaviour. 

In my testing, most WMS servers will work either way. For servers that require the trailing slash, it can still be included in the `url` attribute of the `WMS` layer. 

(The server of the WMS example seems to be broken, so I couldn't test it there)

