### PR TITLE
Fix `CompassButton` for mobile devices

### DIFF
--- a/src/control/CompassButton.ts
+++ b/src/control/CompassButton.ts
@@ -102,8 +102,8 @@ export class CompassButton extends Control {
         });
 
         btn.appendTo(this.renderer!.div!);
-
         btn.events.on("click", this._onClick, this);
+        btn.events.on("touchstart", this._onClick, this);
 
         this._svg = btn.select("svg");
 


### PR DESCRIPTION
This PR includes a small fix for the `CompassButton` for mobile devices. The `_onClick`-event never fired, because multiple event listeners (`mousedown`, `mouseup`, `touchstart`, etc) call `preventDefault` on the event before the click event could register. 

Now with this fix the `CompassButton` does the same thing as the `ZoomControl`, adding the same callback both on `click` as well as `touchstart`. 