### PR TITLE
terminate workers on destroy

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -1433,6 +1433,8 @@ class Renderer {
     }
 
     public destroy() {
+        this.labelWorker.destroy();
+
         for (let i in this.controls) {
             this.controls[i].remove();
         }

--- a/src/scene/Planet.ts
+++ b/src/scene/Planet.ts
@@ -1988,6 +1988,18 @@ export class Planet extends RenderNode {
         this.quadTreeStrategy.clearRenderedNodes();
     }
 
+    /**
+     * Destroy planet.
+     * @public
+     */
+    public override destroy() {
+        this._terrainWorker.destroy();
+        this._plainSegmentWorker.destroy();
+        this.renderer?.destroy()
+        this.onremove();
+        super.destroy();
+    }
+
     // function checkTerrainCollision(entity) {
     //     let _tempTerrPoint = new Vec3();
     //     let nodes = globus.planet._renderedNodes;

--- a/src/utils/BaseWorker.ts
+++ b/src/utils/BaseWorker.ts
@@ -62,10 +62,8 @@ export class BaseWorker<T> {
             w.onmessage = null;
             w.terminate();
         }
-        //@ts-ignore
-        this._pendingQueue = null;
-        //@ts-ignore
-        this._workerQueue = null;
+        this._pendingQueue = [];
+        this._workerQueue = [];
     }
 
     public get pendingQueue(): T[] {


### PR DESCRIPTION
This PR is an attempted fix #944. 

The `destroy` methods of the worker classes already cleanup correctly, all that was (seemingly) missing was to call them from them from the `Planet` and the `Renderer`. Calling `globus.destroy()` in the OSM example now properly terminates all the workers.

I probably missed some things or simplified this too much, any guidance would be appreciated.