### PR TITLE
Allow partial clearing of layer material

### DIFF
--- a/src/layer/CanvasTiles.ts
+++ b/src/layer/CanvasTiles.ts
@@ -332,9 +332,11 @@ class CanvasTiles extends Layer {
                 //
                 if ((material.layer as CanvasTiles).animated) {
                     requestAnimationFrame(() => {
-                        this.drawTile(material, function (canvas) {
-                            material.applyImage(canvas);
-                        });
+                        if (material.segment) {
+                            this.drawTile(material, function (canvas) {
+                                material.applyImage(canvas);
+                            });
+                        }
                     });
                 }
 

--- a/src/quadTree/QuadTreeStrategy.ts
+++ b/src/quadTree/QuadTreeStrategy.ts
@@ -175,10 +175,18 @@ export class QuadTreeStrategy {
         }
     }
 
-    public clearLayerMaterial(layer: Layer) {
+    /**
+     * clears layer material from the quad tree list. 
+     * @param layer 
+     * @param keepRendered if true, keeps materials that are currently rendered.
+     */
+    public clearLayerMaterial(layer: Layer, keepRendered: boolean = false) {
         let lid = layer.__id;
         for (let i = 0, len = this._quadTreeList.length; i < len; i++) {
-            this._quadTreeList[i].traverseTree(function (node: Node) {
+            this._quadTreeList[i].traverseTree((node: Node) => {
+                if (keepRendered && this._renderedNodes.includes(node)) {
+                    return;
+                }
                 let mats = node.segment.materials;
                 if (mats[lid]) {
                     mats[lid].clear();


### PR DESCRIPTION
The background:

When using a `Canvastiles`-Layer with an external rendering engine, rendering can appear slow due to complex renderings or complex layer composition. Also, when the definition of a `CanvasTiles`-Layer changes (let's say we render 5 different logical layers in a single `openglobus` `Canvastiles` layer and want to change the opacity of a single one of them), until now you had to clear the entire layer and re-render all tiles with the new definition, which results in a remporary blank globe.

This PR adds 2 things:

 - an option `keepRendered` to the existing `clearLayerMaterial` of the `QuadTreeStrategy`
   - this helps to keep the existing rendered tiles, so the globe doesn't become blank
 - another check in `applyMaterial` of `CanvasTiles`-layer
 
 With the combination of these changes, we can clear the layer but keep the rendered tiles and (temporarily) set the `animated` property of the `CanvasTiles` to `true`. This way, when we change the application logic of the `drawTile` callback, we get the new tiles and replace the existing ones, resulting in a smoother and visually faster update of the `CanvasTiles` layer. 
 
 Here is a screenshare of how it was before (clear entire layer):
 

https://github.com/user-attachments/assets/b6bb095b-d87b-4d39-a66d-f4bd74820fe2


Here with the new changes (keep rendered and temporarily "animate" the layer):


https://github.com/user-attachments/assets/3c416459-c59e-4c06-9bb2-1eb65ad58a52


Is there a better way to do this? It seems a bit overkill to animate a layer even though we are only expecting a "single" update to each tile
 
 