### PR TITLE
950. fix

### DIFF
--- a/sandbox/skyBox/skyBox.js
+++ b/sandbox/skyBox/skyBox.js
@@ -3,7 +3,8 @@ import {
     LonLat,
     OpenStreetMap,
     scene,
-    control
+    control,
+    GlobusRgbTerrain
 } from "../../lib/og.es.js";
 
 const skybox = new scene.SkyBox({
@@ -18,12 +19,14 @@ const skybox = new scene.SkyBox({
 const globus = new Globe({
     target: "earth",
     name: "Earth",
+    terrain: new GlobusRgbTerrain(),
     layers: [new OpenStreetMap()],
     atmosphereEnabled: true,
     skybox: skybox,
     controls: [
         new control.MouseNavigation({ minSlope: 0.35 }),
         new control.KeyboardNavigation({ autoActivate: true }),
-        new control.ToggleWireframe()
+        new control.ToggleWireframe(),
+        new control.TimelineControl()
     ]
 })

--- a/sandbox/skyBox/skyBox.js
+++ b/sandbox/skyBox/skyBox.js
@@ -23,6 +23,7 @@ const globus = new Globe({
     skybox: skybox,
     controls: [
         new control.MouseNavigation({ minSlope: 0.35 }),
-        new control.KeyboardNavigation({ autoActivate: true })
+        new control.KeyboardNavigation({ autoActivate: true }),
+        new control.ToggleWireframe()
     ]
 })

--- a/src/control/atmosphere/atmosphere.frag.glsl
+++ b/src/control/atmosphere/atmosphere.frag.glsl
@@ -130,10 +130,11 @@ void mainImage(out vec4 fragColor)
 
         if (intersectSphere(cameraPosition, rayDirection, BOTTOM_RADIUS - 100000.0, distanceToGround) && hitGround)
         {
-            discard;
+            fragColor = vec4(0.47, 0.47, 0.5, 1.0);
+            return;
         }
 
-        float segmentLength = ((hitGround ? distanceToGround : distanceToSpace) - max(offset, 0.0)) / float(SAMPLE_COUNT);
+        float segmentLength = abs(((hitGround ? distanceToGround : distanceToSpace) - max(offset, 0.0)) / float(SAMPLE_COUNT));
 
         float t = segmentLength * 0.5;
 
@@ -194,7 +195,9 @@ void mainImage(out vec4 fragColor)
     }
     #endif
 
-    fragColor = vec4(pow(opacity * light * 8.0, vec3(1.0 / 2.2)), valueHSV(light) * clamp(opacity, 0.0, 1.0));
+    vec4 color = vec4(pow(opacity * light * 8.0, vec3(1.0 / 2.2)), valueHSV(light) * clamp(opacity, 0.0, 1.0));
+
+    fragColor = color;
 }
 
 void main(void)

--- a/src/scene/SkyBox.ts
+++ b/src/scene/SkyBox.ts
@@ -33,7 +33,7 @@ class SkyBox extends RenderNode {
         this.drawMode = this.renderer!.handler.gl!.TRIANGLES;
     }
 
-    public override frame() {
+    public override preFrame() {
         let h = this.renderer!.handler;
         let gl = h.gl!;
         let cam = this.renderer!.activeCamera!;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds RGB terrain and wireframe/timeline controls to the skybox demo, updates the atmosphere shader to color underground rays and use abs segment length, and moves skybox rendering to preFrame.
> 
> - **Sandbox demo (`sandbox/skyBox/skyBox.js`)**:
>   - Add `GlobusRgbTerrain` to `Globe` and enable `control.ToggleWireframe()` and `control.TimelineControl()`.
> - **Atmosphere shader (`src/control/atmosphere/atmosphere.frag.glsl`)**:
>   - Replace `discard` with a grey `fragColor` and early `return` when ray intersects below-ground sphere.
>   - Use `abs` for `segmentLength` in raymarching; minor final color refactor.
> - **SkyBox (`src/scene/SkyBox.ts`)**:
>   - Move render path from `frame()` to `preFrame()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10d5f9993485792d27a2699cf6b1e484e127251d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->