### PR TITLE
Use lightgrey fallback and warn for unknown color names #1054

### DIFF
--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -108,6 +108,8 @@ export function rgbToStringHTML(rgb: NumberArray3 | Vec3): string {
     return `#${r}${g}${b}`;
 }
 
+const LIGHTGREY = 211 / 255;
+
 /**
  * Convert html color string to the RGBA number vector.
  * @param {string} htmlColor - HTML string("#C6C6C6" or "#EF5" or "rgb(8,8,8)" or "rgba(8,8,8)") color.
@@ -118,9 +120,9 @@ export function htmlColorToRgba(htmlColor: string, opacity?: number): Vec4 {
     let hColor: any | undefined = colorTable[htmlColor];
     if (hColor) {
         htmlColor = hColor;
-    } else if (htmlColor[0] !== "#" && !htmlColor.includes("(")) {
-        console.warn(`Unknown color name "${htmlColor}", using lightgrey as fallback.`);
-        htmlColor = colorTable["lightgrey"];
+    } else if (htmlColor[0] !== "#" && !htmlColor.startsWith("rgb")) {
+        console.warn(`Invalid or unknown color "${htmlColor}", using lightgrey as fallback.`);
+        htmlColor = colorTable.lightgrey;
     }
 
     if (htmlColor[0] === "#") {
@@ -137,13 +139,18 @@ export function htmlColorToRgba(htmlColor: string, opacity?: number): Vec4 {
                 isEmpty(opacity) ? 1.0 : opacity
             );
         } else {
-            return new Vec4();
+            console.warn(`Invalid color "${htmlColor}", using lightgrey as fallback.`);
+            return new Vec4(LIGHTGREY, LIGHTGREY, LIGHTGREY, isEmpty(opacity) ? 1.0 : opacity);
         }
     } else {
         if (isEmpty(opacity)) {
             opacity = 1.0;
         }
         let m = htmlColor.split(",");
+        if (m.length < 3) {
+            console.warn(`Invalid color "${htmlColor}", using lightgrey as fallback.`);
+            return new Vec4(LIGHTGREY, LIGHTGREY, LIGHTGREY, opacity);
+        }
         return new Vec4(
             parseInt(m[0].split("(")[1]) / 255,
             parseInt(m[1]) / 255,
@@ -167,9 +174,9 @@ export function htmlColorToRgb(htmlColor: string): Vec3 {
     let hColor: any | undefined = colorTable[htmlColor];
     if (hColor) {
         htmlColor = hColor;
-    } else if (htmlColor[0] !== "#" && !htmlColor.includes("(")) {
-        console.warn(`Unknown color name "${htmlColor}", using lightgrey as fallback.`);
-        htmlColor = colorTable["lightgrey"];
+    } else if (htmlColor[0] !== "#" && !htmlColor.startsWith("rgb")) {
+        console.warn(`Invalid or unknown color "${htmlColor}", using lightgrey as fallback.`);
+        htmlColor = colorTable.lightgrey;
     }
 
     if (htmlColor[0] === "#") {
@@ -185,10 +192,15 @@ export function htmlColorToRgb(htmlColor: string): Vec3 {
                 parseInt(result[3], 16) / 255
             );
         } else {
-            return new Vec3();
+            console.warn(`Invalid color "${htmlColor}", using lightgrey as fallback.`);
+            return new Vec3(LIGHTGREY, LIGHTGREY, LIGHTGREY);
         }
     } else {
         let m = htmlColor.split(",");
+        if (m.length < 3) {
+            console.warn(`Invalid color "${htmlColor}", using lightgrey as fallback.`);
+            return new Vec3(LIGHTGREY, LIGHTGREY, LIGHTGREY);
+        }
         return new Vec3(parseInt(m[0].split("(")[1]) / 255, parseInt(m[1]) / 255, parseInt(m[2]) / 255);
     }
 }

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -118,6 +118,9 @@ export function htmlColorToRgba(htmlColor: string, opacity?: number): Vec4 {
     let hColor: any | undefined = colorTable[htmlColor];
     if (hColor) {
         htmlColor = hColor;
+    } else if (htmlColor[0] !== "#" && !htmlColor.includes("(")) {
+        console.warn(`Unknown color name "${htmlColor}", using lightgrey as fallback.`);
+        htmlColor = colorTable["lightgrey"];
     }
 
     if (htmlColor[0] === "#") {
@@ -164,6 +167,9 @@ export function htmlColorToRgb(htmlColor: string): Vec3 {
     let hColor: any | undefined = colorTable[htmlColor];
     if (hColor) {
         htmlColor = hColor;
+    } else if (htmlColor[0] !== "#" && !htmlColor.includes("(")) {
+        console.warn(`Unknown color name "${htmlColor}", using lightgrey as fallback.`);
+        htmlColor = colorTable["lightgrey"];
     }
 
     if (htmlColor[0] === "#") {

--- a/tests/shared.test.js
+++ b/tests/shared.test.js
@@ -192,7 +192,7 @@ test('Test htmlColorToRgba unknown color name fallback', () => {
     expect(res.y).toBeCloseTo(211 / 255);
     expect(res.z).toBeCloseTo(211 / 255);
     expect(res.w).toBe(1);
-    expect(warn).toHaveBeenCalledWith('Unknown color name "dark_olive", using lightgrey as fallback.');
+    expect(warn).toHaveBeenCalledWith('Invalid or unknown color "dark_olive", using lightgrey as fallback.');
 
     warn.mockRestore();
 });
@@ -206,7 +206,37 @@ test('Test htmlColorToRgb unknown color name fallback', () => {
     expect(res.x).toBeCloseTo(211 / 255);
     expect(res.y).toBeCloseTo(211 / 255);
     expect(res.z).toBeCloseTo(211 / 255);
-    expect(warn).toHaveBeenCalledWith('Unknown color name "dark_olive", using lightgrey as fallback.');
+    expect(warn).toHaveBeenCalledWith('Invalid or unknown color "dark_olive", using lightgrey as fallback.');
+
+    warn.mockRestore();
+});
+
+test('Test htmlColorToRgba invalid hex fallback', () => {
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let res = shared.htmlColorToRgba('#zzz');
+
+    expect(res.x).toBeCloseTo(211 / 255);
+    expect(res.y).toBeCloseTo(211 / 255);
+    expect(res.z).toBeCloseTo(211 / 255);
+    expect(res.w).toBe(1);
+    expect(warn).toHaveBeenCalledWith('Invalid color "#zzz", using lightgrey as fallback.');
+
+    warn.mockRestore();
+});
+
+test('Test htmlColorToRgba malformed rgb fallback', () => {
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let res = shared.htmlColorToRgba('rgb(8)');
+
+    expect(res.x).toBeCloseTo(211 / 255);
+    expect(res.y).toBeCloseTo(211 / 255);
+    expect(res.z).toBeCloseTo(211 / 255);
+    expect(res.w).toBe(1);
+    expect(warn).toHaveBeenCalledWith('Invalid color "rgb(8)", using lightgrey as fallback.');
 
     warn.mockRestore();
 });

--- a/tests/shared.test.js
+++ b/tests/shared.test.js
@@ -171,3 +171,42 @@ test('Test spliceTypedArray', () => {
 
     expect(res).toEqual(tc);
 });
+
+test('Test htmlColorToRgba known color name', () => {
+
+    let res = shared.htmlColorToRgba('red');
+
+    expect(res.x).toBe(1);
+    expect(res.y).toBe(0);
+    expect(res.z).toBe(0);
+    expect(res.w).toBe(1);
+});
+
+test('Test htmlColorToRgba unknown color name fallback', () => {
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let res = shared.htmlColorToRgba('dark_olive');
+
+    expect(res.x).toBeCloseTo(211 / 255);
+    expect(res.y).toBeCloseTo(211 / 255);
+    expect(res.z).toBeCloseTo(211 / 255);
+    expect(res.w).toBe(1);
+    expect(warn).toHaveBeenCalledWith('Unknown color name "dark_olive", using lightgrey as fallback.');
+
+    warn.mockRestore();
+});
+
+test('Test htmlColorToRgb unknown color name fallback', () => {
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let res = shared.htmlColorToRgb('dark_olive');
+
+    expect(res.x).toBeCloseTo(211 / 255);
+    expect(res.y).toBeCloseTo(211 / 255);
+    expect(res.z).toBeCloseTo(211 / 255);
+    expect(warn).toHaveBeenCalledWith('Unknown color name "dark_olive", using lightgrey as fallback.');
+
+    warn.mockRestore();
+});


### PR DESCRIPTION
  ## Summary

If a color name is not found in the color table, `htmlColorToRgba()` and `htmlColorToRgb()` in `src/utils/shared.ts` produced a black/NaN color, making objects invisible on a black background. Unknown color names now fall back to `lightgrey` (`#d3d3d3` from the color table) and log a `console.warn` with the unknown name. Valid hex and `rgb()`/`rgba()` inputs are unaffected. Added tests covering the fallback and warning for both functions, plus a known name regression check.

  ## Related Issue

  - Closes #1054

  ## Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Refactor/maintenance

  ## Validation

  - [x] `npm run lint`
  - [x] `npm run test`
  - [x] `npm run build`
  - [x] `npm run format`

  ## Checklist

  - [x] PR title is clear and scoped
  - [x] Changes are minimal and focused
  - [x] Documentation updated when needed
  - [x] No unrelated changes included